### PR TITLE
DX-010: PreToolUse hook scripts for agent permission enforcement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,15 +34,13 @@ ai-lindale/
 ├── memory/
 │   ├── MEMORY_INDEX.md    # Index of all topic files
 │   └── *.md               # Topic-scoped memory files
-├── scripts/
-│   └── hooks/             # PreToolUse enforcement scripts
-│       ├── enforce-write-paths.sh
-│       ├── bash-allowlist.sh
-│       ├── block-sensitive-files.sh
-│       └── tests/
-│           └── test-hooks.sh
-└── templates/
-    └── team-config.yml    # Template for downstream project config
+└── scripts/
+    └── hooks/             # PreToolUse enforcement scripts
+        ├── enforce-write-paths.sh
+        ├── bash-allowlist.sh
+        ├── block-sensitive-files.sh
+        └── tests/
+            └── test-hooks.sh
 ```
 
 ## Enforcement Layers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,14 +34,16 @@ ai-lindale/
 ├── memory/
 │   ├── MEMORY_INDEX.md    # Index of all topic files
 │   └── *.md               # Topic-scoped memory files
-└── scripts/
-    └── hooks/             # PreToolUse enforcement scripts (DX-010)
-        ├── enforce-write-paths.sh
-        ├── bash-allowlist.sh
-        └── block-sensitive-files.sh
+├── scripts/
+│   └── hooks/             # PreToolUse enforcement scripts
+│       ├── enforce-write-paths.sh
+│       ├── bash-allowlist.sh
+│       ├── block-sensitive-files.sh
+│       └── tests/
+│           └── test-hooks.sh
+└── templates/
+    └── team-config.yml    # Template for downstream project config
 ```
-
-> Hook scripts are planned (DX-010). Agent defs reference them but they don't exist yet.
 
 ## Enforcement Layers
 

--- a/scripts/hooks/bash-allowlist.sh
+++ b/scripts/hooks/bash-allowlist.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# PreToolUse hook: enforces per-role Bash command restrictions.
+#
+# - TPM/Architect: allowlist approach (only safe read-only commands)
+# - Consultant: very restricted (gh issue only)
+# - Dev: denylist approach (block destructive git operations)
+#
+# Exit 0 = allow, exit 2 = block (stdout shown to agent as reason).
+
+set -euo pipefail
+
+ROLE="${CLAUDE_AGENT_ROLE:-}"
+
+if [ -z "$ROLE" ]; then
+  echo "BLOCKED: CLAUDE_AGENT_ROLE not set. Cannot determine command permissions."
+  exit 2
+fi
+
+# Read JSON from stdin
+INPUT=$(cat)
+
+# Extract command from tool_input
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# --- Command extraction ---
+# Split command on pipes, &&, ||, ; and check each segment.
+# Also detect $(...) subshell escapes.
+
+extract_commands() {
+  local cmd="$1"
+  # Replace pipe, &&, ||, ; with newlines to get individual commands
+  echo "$cmd" | sed -E 's/\|{1,2}/\n/g; s/&&/\n/g; s/;/\n/g' | sed 's/^[[:space:]]*//'
+}
+
+check_subshell_escapes() {
+  local cmd="$1"
+  # Check for $(...) subshell syntax
+  if echo "$cmd" | grep -qE '\$\('; then
+    return 1
+  fi
+  return 0
+}
+
+get_base_command() {
+  # Extract the first word (the actual command) from a command string
+  local segment="$1"
+  echo "$segment" | awk '{print $1}'
+}
+
+# --- Allowlist: read-only commands for TPM and Architect ---
+
+READONLY_COMMANDS="gh git grep cat ls head tail wc sort uniq diff find echo printf test basename dirname"
+
+is_readonly_git() {
+  local cmd="$1"
+  # Allow read-only git subcommands only
+  if echo "$cmd" | grep -qE '^git\s+(status|log|diff|show|branch|remote|tag|rev-parse|ls-files|ls-tree|blame|shortlog|describe|config\s+--get|stash\s+list)'; then
+    return 0
+  fi
+  # Block all other git operations
+  if echo "$cmd" | grep -qE '^git\s+'; then
+    return 1
+  fi
+  # Not a git command
+  return 0
+}
+
+# --- Role checks ---
+
+check_consultant() {
+  local cmd="$1"
+  # Consultant: only gh issue view/comment/list
+  local segments
+  segments=$(extract_commands "$cmd")
+
+  # Check for subshell escapes
+  if ! check_subshell_escapes "$cmd"; then
+    echo "BLOCKED: Subshell expressions not allowed for consultant role"
+    return 2
+  fi
+
+  while IFS= read -r segment; do
+    [ -z "$segment" ] && continue
+    local base
+    base=$(get_base_command "$segment")
+
+    if [ "$base" = "gh" ]; then
+      # Only allow gh issue subcommands
+      if echo "$segment" | grep -qE '^gh\s+issue\s+(view|comment|list)'; then
+        continue
+      fi
+      echo "BLOCKED: Consultant can only use 'gh issue view/comment/list' (attempted: '$segment')"
+      return 2
+    fi
+
+    # Everything else is blocked for consultant
+    echo "BLOCKED: Consultant can only use 'gh issue' commands (attempted: '$segment')"
+    return 2
+  done <<< "$segments"
+
+  return 0
+}
+
+check_allowlist_role() {
+  local cmd="$1" role="$2"
+  local segments
+  segments=$(extract_commands "$cmd")
+
+  # Check for subshell escapes
+  if ! check_subshell_escapes "$cmd"; then
+    echo "BLOCKED: Subshell expressions not allowed for $role role"
+    return 2
+  fi
+
+  while IFS= read -r segment; do
+    [ -z "$segment" ] && continue
+    local base
+    base=$(get_base_command "$segment")
+
+    # xargs can execute arbitrary commands
+    if [ "$base" = "xargs" ]; then
+      echo "BLOCKED: 'xargs' not allowed for $role role"
+      return 2
+    fi
+
+    # Check if base command is in the allowlist
+    if ! echo " $READONLY_COMMANDS " | grep -q " $base "; then
+      echo "BLOCKED: Command '$base' not allowed for $role role"
+      return 2
+    fi
+
+    # If it's git, check for read-only subcommands
+    if [ "$base" = "git" ]; then
+      if ! is_readonly_git "$segment"; then
+        echo "BLOCKED: Git write operation not allowed for $role role (attempted: '$segment')"
+        return 2
+      fi
+    fi
+  done <<< "$segments"
+
+  return 0
+}
+
+check_dev() {
+  local cmd="$1"
+
+  # Dev denylist: block destructive operations
+  # Force push
+  if echo "$cmd" | grep -qE 'git\s+push\s+.*--force'; then
+    echo "BLOCKED: Force push not allowed for dev role"
+    return 2
+  fi
+  if echo "$cmd" | grep -qE 'git\s+push\s+.*-f(\s|$)'; then
+    echo "BLOCKED: Force push not allowed for dev role"
+    return 2
+  fi
+
+  # Hard reset
+  if echo "$cmd" | grep -qE 'git\s+reset\s+--hard'; then
+    echo "BLOCKED: Hard reset not allowed for dev role"
+    return 2
+  fi
+
+  # Push to main/master
+  if echo "$cmd" | grep -qE 'git\s+push\s+\S+\s+(main|master)(\s|$)'; then
+    echo "BLOCKED: Pushing directly to main/master not allowed for dev role"
+    return 2
+  fi
+
+  return 0
+}
+
+# --- Dispatch by role ---
+
+case "$ROLE" in
+  tpm|architect)
+    check_allowlist_role "$COMMAND" "$ROLE"
+    exit $?
+    ;;
+  *-consultant|consultant)
+    check_consultant "$COMMAND"
+    exit $?
+    ;;
+  dev)
+    check_dev "$COMMAND"
+    exit $?
+    ;;
+  *)
+    # Unknown role — fail closed
+    echo "BLOCKED: Unknown role '$ROLE'"
+    exit 2
+    ;;
+esac

--- a/scripts/hooks/bash-allowlist.sh
+++ b/scripts/hooks/bash-allowlist.sh
@@ -6,8 +6,19 @@
 # - Dev: denylist approach (block destructive git operations)
 #
 # Exit 0 = allow, exit 2 = block (stdout shown to agent as reason).
+#
+# Known limitations (acceptable given defense-in-depth with sandbox + worktree):
+# - Quoted pipes: `grep "foo|bar"` may be incorrectly split on |
+# - Backtick subshells: `cmd` not detected (only $(cmd) is caught)
+# - Heredocs: can smuggle commands past the parser
 
 set -euo pipefail
+
+# Guard: jq required for JSON parsing
+if ! command -v jq &>/dev/null; then
+  echo "BLOCKED: jq is required but not installed"
+  exit 2
+fi
 
 ROLE="${CLAUDE_AGENT_ROLE:-}"
 
@@ -148,13 +159,16 @@ check_allowlist_role() {
 check_dev() {
   local cmd="$1"
 
-  # Dev denylist: block destructive operations
-  # Force push
+  # Dev denylist: block destructive operations.
+  # Note: denylist is inherently incomplete — worktree isolation (enforcement
+  # layer 4) limits blast radius for any gaps not caught here.
+
+  # Force push (--force, --force-with-lease, -f, bundled -f e.g. -fu)
   if echo "$cmd" | grep -qE 'git\s+push\s+.*--force'; then
     echo "BLOCKED: Force push not allowed for dev role"
     return 2
   fi
-  if echo "$cmd" | grep -qE 'git\s+push\s+.*-f(\s|$)'; then
+  if echo "$cmd" | grep -qE 'git\s+push\s+.*-[a-zA-Z]*f'; then
     echo "BLOCKED: Force push not allowed for dev role"
     return 2
   fi
@@ -162,6 +176,20 @@ check_dev() {
   # Hard reset
   if echo "$cmd" | grep -qE 'git\s+reset\s+--hard'; then
     echo "BLOCKED: Hard reset not allowed for dev role"
+    return 2
+  fi
+
+  # Destructive working tree operations
+  if echo "$cmd" | grep -qE 'git\s+checkout\s+\.\s*$'; then
+    echo "BLOCKED: 'git checkout .' discards uncommitted changes — not allowed for dev role"
+    return 2
+  fi
+  if echo "$cmd" | grep -qE 'git\s+restore\s+\.'; then
+    echo "BLOCKED: 'git restore .' discards uncommitted changes — not allowed for dev role"
+    return 2
+  fi
+  if echo "$cmd" | grep -qE 'git\s+clean\s+-[a-zA-Z]*f'; then
+    echo "BLOCKED: 'git clean -f' deletes untracked files — not allowed for dev role"
     return 2
   fi
 
@@ -182,6 +210,8 @@ case "$ROLE" in
     exit $?
     ;;
   *-consultant|consultant)
+    # Matches any role ending in -consultant (e.g. astrology-consultant).
+    # Intentionally broad — fails toward more restrictive (safe direction).
     check_consultant "$COMMAND"
     exit $?
     ;;

--- a/scripts/hooks/block-sensitive-files.sh
+++ b/scripts/hooks/block-sensitive-files.sh
@@ -6,6 +6,12 @@
 
 set -euo pipefail
 
+# Guard: jq required for JSON parsing
+if ! command -v jq &>/dev/null; then
+  echo "BLOCKED: jq is required but not installed"
+  exit 2
+fi
+
 # Read JSON from stdin
 INPUT=$(cat)
 

--- a/scripts/hooks/block-sensitive-files.sh
+++ b/scripts/hooks/block-sensitive-files.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# PreToolUse hook: blocks writes to sensitive files regardless of agent role.
+# Applies to Write and Edit tool calls.
+#
+# Exit 0 = allow, exit 2 = block (stdout shown to agent as reason).
+
+set -euo pipefail
+
+# Read JSON from stdin
+INPUT=$(cat)
+
+# Extract file_path from tool_input
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$FILE_PATH" ]; then
+  # No file_path in input — not a Write/Edit call, allow
+  exit 0
+fi
+
+BASENAME=$(basename "$FILE_PATH")
+# Lowercase for case-insensitive matching
+BASENAME_LOWER=$(echo "$BASENAME" | tr '[:upper:]' '[:lower:]')
+
+# --- Sensitive basename patterns ---
+
+# .env files
+if [[ "$BASENAME_LOWER" == .env* ]]; then
+  echo "BLOCKED: Writing to sensitive file '$FILE_PATH' (.env* pattern)"
+  exit 2
+fi
+
+# credentials files
+if [[ "$BASENAME_LOWER" == credentials* ]]; then
+  echo "BLOCKED: Writing to sensitive file '$FILE_PATH' (credentials* pattern)"
+  exit 2
+fi
+
+# Private keys and certificates
+if [[ "$BASENAME_LOWER" == *.key ]] || [[ "$BASENAME_LOWER" == *.pem ]]; then
+  echo "BLOCKED: Writing to sensitive file '$FILE_PATH' (key/certificate pattern)"
+  exit 2
+fi
+
+# Secrets files
+if [[ "$BASENAME_LOWER" == secrets.* ]] || [[ "$BASENAME_LOWER" == secrets ]]; then
+  echo "BLOCKED: Writing to sensitive file '$FILE_PATH' (secrets pattern)"
+  exit 2
+fi
+
+# SSH keys
+if [[ "$BASENAME_LOWER" == id_rsa* ]] || [[ "$BASENAME_LOWER" == id_ed25519* ]] || [[ "$BASENAME_LOWER" == id_ecdsa* ]]; then
+  echo "BLOCKED: Writing to sensitive file '$FILE_PATH' (SSH key pattern)"
+  exit 2
+fi
+
+# --- Sensitive directory patterns ---
+
+if [[ "$FILE_PATH" == *.ssh/* ]] || [[ "$FILE_PATH" == .ssh/* ]]; then
+  echo "BLOCKED: Writing to sensitive directory '$FILE_PATH' (.ssh/)"
+  exit 2
+fi
+
+if [[ "$FILE_PATH" == *.gnupg/* ]] || [[ "$FILE_PATH" == .gnupg/* ]]; then
+  echo "BLOCKED: Writing to sensitive directory '$FILE_PATH' (.gnupg/)"
+  exit 2
+fi
+
+if [[ "$FILE_PATH" == *.aws/* ]] || [[ "$FILE_PATH" == .aws/* ]]; then
+  echo "BLOCKED: Writing to sensitive directory '$FILE_PATH' (.aws/)"
+  exit 2
+fi
+
+# All checks passed — allow
+exit 0

--- a/scripts/hooks/enforce-write-paths.sh
+++ b/scripts/hooks/enforce-write-paths.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# PreToolUse hook: enforces per-role write path restrictions.
+# Only roles with restricted write access need this hook (currently: TPM).
+#
+# Exit 0 = allow, exit 2 = block (stdout shown to agent as reason).
+
+set -euo pipefail
+
+ROLE="${CLAUDE_AGENT_ROLE:-}"
+
+if [ -z "$ROLE" ]; then
+  echo "BLOCKED: CLAUDE_AGENT_ROLE not set. Cannot determine write permissions."
+  exit 2
+fi
+
+# Read JSON from stdin
+INPUT=$(cat)
+
+# Extract file_path from tool_input
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# --- Security checks (all roles) ---
+
+# Block absolute paths
+if [[ "$FILE_PATH" == /* ]]; then
+  echo "BLOCKED: Absolute paths are not allowed ('$FILE_PATH')"
+  exit 2
+fi
+
+# Block path traversal
+if [[ "$FILE_PATH" == *..* ]]; then
+  echo "BLOCKED: Path traversal is not allowed ('$FILE_PATH')"
+  exit 2
+fi
+
+# --- Role-specific allowlists ---
+
+case "$ROLE" in
+  tpm)
+    # TPM can only write to memory/ and .claude/
+    if [[ "$FILE_PATH" == memory/* ]] || [[ "$FILE_PATH" == .claude/* ]]; then
+      exit 0
+    fi
+    echo "BLOCKED: TPM can only write to memory/ and .claude/ (attempted: '$FILE_PATH')"
+    exit 2
+    ;;
+  *)
+    # Roles without write path restrictions pass through
+    # (Dev uses block-sensitive-files.sh instead; Architect/Consultant have disallowedTools)
+    exit 0
+    ;;
+esac

--- a/scripts/hooks/enforce-write-paths.sh
+++ b/scripts/hooks/enforce-write-paths.sh
@@ -6,6 +6,12 @@
 
 set -euo pipefail
 
+# Guard: jq required for JSON parsing
+if ! command -v jq &>/dev/null; then
+  echo "BLOCKED: jq is required but not installed"
+  exit 2
+fi
+
 ROLE="${CLAUDE_AGENT_ROLE:-}"
 
 if [ -z "$ROLE" ]; then

--- a/scripts/hooks/tests/test-hooks.sh
+++ b/scripts/hooks/tests/test-hooks.sh
@@ -15,19 +15,6 @@ HOOKS="$REPO_ROOT/scripts/hooks"
 
 # --- Helpers ---
 
-run_hook() {
-  local script="$1"
-  local json="$2"
-  local env_role="${3:-}"
-  local exit_code=0
-  if [ -n "$env_role" ]; then
-    CLAUDE_AGENT_ROLE="$env_role" echo "$json" | bash "$HOOKS/$script" >/dev/null 2>&1 || exit_code=$?
-  else
-    echo "$json" | bash "$HOOKS/$script" >/dev/null 2>&1 || exit_code=$?
-  fi
-  return $exit_code
-}
-
 expect_allow() {
   local name="$1" script="$2" json="$3" role="${4:-}"
   local exit_code=0
@@ -260,6 +247,16 @@ expect_block "Consultant: ls blocked" \
   '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' \
   "astrology-consultant"
 
+expect_block "Consultant: gh pr blocked" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr view 1"}}' \
+  "astrology-consultant"
+
+expect_block "Consultant: gh pr create blocked" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh pr create --title \"test\""}}' \
+  "astrology-consultant"
+
 echo ""
 echo "=== bash-allowlist.sh (Dev) ==="
 
@@ -296,6 +293,31 @@ expect_block "Dev: git push to main blocked" \
 expect_block "Dev: git push to master blocked" \
   "bash-allowlist.sh" \
   '{"tool_name":"Bash","tool_input":{"command":"git push origin master"}}' \
+  "dev"
+
+expect_block "Dev: git push --force-with-lease blocked" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease"}}' \
+  "dev"
+
+expect_block "Dev: git push -fu (bundled flags) blocked" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git push -fu origin branch"}}' \
+  "dev"
+
+expect_block "Dev: git checkout . blocked" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git checkout ."}}' \
+  "dev"
+
+expect_block "Dev: git restore . blocked" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git restore ."}}' \
+  "dev"
+
+expect_block "Dev: git clean -fd blocked" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git clean -fd"}}' \
   "dev"
 
 echo ""

--- a/scripts/hooks/tests/test-hooks.sh
+++ b/scripts/hooks/tests/test-hooks.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+# DX-010: Tests for PreToolUse hook scripts.
+# Run from repo root: bash scripts/hooks/tests/test-hooks.sh
+#
+# Hook protocol: stdin receives JSON {"tool_name":"...","tool_input":{...}}
+# Exit 0 = allow, exit 2 = block (stdout = reason shown to agent).
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HOOKS="$REPO_ROOT/scripts/hooks"
+
+# --- Helpers ---
+
+run_hook() {
+  local script="$1"
+  local json="$2"
+  local env_role="${3:-}"
+  local exit_code=0
+  if [ -n "$env_role" ]; then
+    CLAUDE_AGENT_ROLE="$env_role" echo "$json" | bash "$HOOKS/$script" >/dev/null 2>&1 || exit_code=$?
+  else
+    echo "$json" | bash "$HOOKS/$script" >/dev/null 2>&1 || exit_code=$?
+  fi
+  return $exit_code
+}
+
+expect_allow() {
+  local name="$1" script="$2" json="$3" role="${4:-}"
+  local exit_code=0
+  if [ -n "$role" ]; then
+    CLAUDE_AGENT_ROLE="$role" bash -c "echo '$json' | bash '$HOOKS/$script'" >/dev/null 2>&1 || exit_code=$?
+  else
+    bash -c "echo '$json' | bash '$HOOKS/$script'" >/dev/null 2>&1 || exit_code=$?
+  fi
+  if [ "$exit_code" -eq 0 ]; then
+    echo "  PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (expected allow/0, got $exit_code)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+expect_block() {
+  local name="$1" script="$2" json="$3" role="${4:-}"
+  local exit_code=0
+  if [ -n "$role" ]; then
+    CLAUDE_AGENT_ROLE="$role" bash -c "echo '$json' | bash '$HOOKS/$script'" >/dev/null 2>&1 || exit_code=$?
+  else
+    bash -c "echo '$json' | bash '$HOOKS/$script'" >/dev/null 2>&1 || exit_code=$?
+  fi
+  if [ "$exit_code" -eq 2 ]; then
+    echo "  PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (expected block/2, got $exit_code)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- block-sensitive-files.sh ---
+
+echo "=== block-sensitive-files.sh ==="
+
+expect_block "blocks .env" \
+  "block-sensitive-files.sh" \
+  '{"tool_name":"Write","tool_input":{"file_path":".env","content":"SECRET=x"}}'
+
+expect_block "blocks .env.local" \
+  "block-sensitive-files.sh" \
+  '{"tool_name":"Write","tool_input":{"file_path":".env.local","content":"x"}}'
+
+expect_block "blocks .env.production" \
+  "block-sensitive-files.sh" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"config/.env.production","old_string":"a","new_string":"b"}}'
+
+expect_block "blocks credentials.json" \
+  "block-sensitive-files.sh" \
+  '{"tool_name":"Write","tool_input":{"file_path":"credentials.json","content":"{}"}}'
+
+expect_block "blocks *.key" \
+  "block-sensitive-files.sh" \
+  '{"tool_name":"Write","tool_input":{"file_path":"server.key","content":"x"}}'
+
+expect_block "blocks *.pem" \
+  "block-sensitive-files.sh" \
+  '{"tool_name":"Write","tool_input":{"file_path":"certs/ca.pem","content":"x"}}'
+
+expect_block "blocks secrets.yml" \
+  "block-sensitive-files.sh" \
+  '{"tool_name":"Write","tool_input":{"file_path":"deploy/secrets.yml","content":"x"}}'
+
+expect_block "blocks id_rsa" \
+  "block-sensitive-files.sh" \
+  '{"tool_name":"Write","tool_input":{"file_path":"id_rsa","content":"x"}}'
+
+expect_block "blocks .ssh/ directory" \
+  "block-sensitive-files.sh" \
+  '{"tool_name":"Write","tool_input":{"file_path":".ssh/config","content":"x"}}'
+
+expect_block "blocks .aws/ directory" \
+  "block-sensitive-files.sh" \
+  '{"tool_name":"Write","tool_input":{"file_path":".aws/credentials","content":"x"}}'
+
+expect_allow "allows normal source file" \
+  "block-sensitive-files.sh" \
+  '{"tool_name":"Write","tool_input":{"file_path":"src/main.js","content":"x"}}'
+
+expect_allow "allows markdown" \
+  "block-sensitive-files.sh" \
+  '{"tool_name":"Write","tool_input":{"file_path":"docs/guide.md","content":"x"}}'
+
+expect_allow "allows package.json" \
+  "block-sensitive-files.sh" \
+  '{"tool_name":"Write","tool_input":{"file_path":"package.json","content":"{}"}}'
+
+echo ""
+
+# --- enforce-write-paths.sh ---
+
+echo "=== enforce-write-paths.sh ==="
+
+expect_allow "TPM can write to memory/" \
+  "enforce-write-paths.sh" \
+  '{"tool_name":"Write","tool_input":{"file_path":"memory/decisions.md","content":"x"}}' \
+  "tpm"
+
+expect_allow "TPM can write to .claude/" \
+  "enforce-write-paths.sh" \
+  '{"tool_name":"Edit","tool_input":{"file_path":".claude/team-config.yml","old_string":"a","new_string":"b"}}' \
+  "tpm"
+
+expect_block "TPM blocked from src/" \
+  "enforce-write-paths.sh" \
+  '{"tool_name":"Write","tool_input":{"file_path":"src/index.js","content":"x"}}' \
+  "tpm"
+
+expect_block "TPM blocked from root files" \
+  "enforce-write-paths.sh" \
+  '{"tool_name":"Write","tool_input":{"file_path":"README.md","content":"x"}}' \
+  "tpm"
+
+expect_block "blocks absolute paths" \
+  "enforce-write-paths.sh" \
+  '{"tool_name":"Write","tool_input":{"file_path":"/etc/passwd","content":"x"}}' \
+  "tpm"
+
+expect_block "blocks path traversal" \
+  "enforce-write-paths.sh" \
+  '{"tool_name":"Write","tool_input":{"file_path":"memory/../../etc/passwd","content":"x"}}' \
+  "tpm"
+
+expect_block "missing role blocks write" \
+  "enforce-write-paths.sh" \
+  '{"tool_name":"Write","tool_input":{"file_path":"memory/test.md","content":"x"}}'
+
+echo ""
+
+# --- bash-allowlist.sh ---
+
+echo "=== bash-allowlist.sh (TPM) ==="
+
+expect_allow "TPM: gh issue list" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue list"}}' \
+  "tpm"
+
+expect_allow "TPM: git status" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git status"}}' \
+  "tpm"
+
+expect_allow "TPM: git log" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git log --oneline -10"}}' \
+  "tpm"
+
+expect_allow "TPM: grep" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"grep -r TODO src/"}}' \
+  "tpm"
+
+expect_allow "TPM: cat" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat README.md"}}' \
+  "tpm"
+
+expect_allow "TPM: ls" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' \
+  "tpm"
+
+expect_block "TPM: git push blocked" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git push"}}' \
+  "tpm"
+
+expect_block "TPM: git commit blocked" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"test\""}}' \
+  "tpm"
+
+expect_block "TPM: rm blocked" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"rm -rf ."}}' \
+  "tpm"
+
+expect_block "TPM: curl blocked" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"curl https://example.com"}}' \
+  "tpm"
+
+echo ""
+echo "=== bash-allowlist.sh (Architect) ==="
+
+expect_allow "Architect: gh issue comment" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue comment 5 --body \"plan\""}}' \
+  "architect"
+
+expect_allow "Architect: git diff" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git diff HEAD"}}' \
+  "architect"
+
+expect_block "Architect: git commit blocked" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"test\""}}' \
+  "architect"
+
+echo ""
+echo "=== bash-allowlist.sh (Consultant) ==="
+
+expect_allow "Consultant: gh issue view" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue view 5"}}' \
+  "astrology-consultant"
+
+expect_allow "Consultant: gh issue comment" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue comment 5 --body \"looks good\""}}' \
+  "astrology-consultant"
+
+expect_allow "Consultant: gh issue list" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"gh issue list"}}' \
+  "astrology-consultant"
+
+expect_block "Consultant: git blocked" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git status"}}' \
+  "astrology-consultant"
+
+expect_block "Consultant: ls blocked" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' \
+  "astrology-consultant"
+
+echo ""
+echo "=== bash-allowlist.sh (Dev) ==="
+
+expect_allow "Dev: npm test" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"npm test"}}' \
+  "dev"
+
+expect_allow "Dev: git commit" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"feat: add thing\""}}' \
+  "dev"
+
+expect_allow "Dev: git push (normal)" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git push -u origin feature-branch"}}' \
+  "dev"
+
+expect_block "Dev: git push --force blocked" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git push --force"}}' \
+  "dev"
+
+expect_block "Dev: git reset --hard blocked" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git reset --hard HEAD~1"}}' \
+  "dev"
+
+expect_block "Dev: git push to main blocked" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git push origin main"}}' \
+  "dev"
+
+expect_block "Dev: git push to master blocked" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git push origin master"}}' \
+  "dev"
+
+echo ""
+echo "=== bash-allowlist.sh (Edge Cases) ==="
+
+expect_allow "pipe: allowed commands" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"git log --oneline | grep fix"}}' \
+  "tpm"
+
+expect_block "pipe: disallowed in pipe" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"ls | xargs rm"}}' \
+  "tpm"
+
+expect_block "subshell escape: \$(rm -rf)" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"echo $(rm -rf /)"}}' \
+  "tpm"
+
+expect_block "chained: && with disallowed" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"ls && rm -rf ."}}' \
+  "tpm"
+
+expect_block "chained: ; with disallowed" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"ls; curl http://evil.com"}}' \
+  "tpm"
+
+expect_block "missing role blocks bash" \
+  "bash-allowlist.sh" \
+  '{"tool_name":"Bash","tool_input":{"command":"ls"}}'
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

- **`scripts/hooks/block-sensitive-files.sh`** — Blocks writes to `.env*`, `credentials*`, `*.key`, `*.pem`, `secrets.*`, `id_rsa*`, `.ssh/`, `.aws/`, `.gnupg/` for all roles
- **`scripts/hooks/enforce-write-paths.sh`** — Restricts TPM to `memory/` and `.claude/` only; blocks absolute paths and path traversal
- **`scripts/hooks/bash-allowlist.sh`** — Allowlist for TPM/Architect (read-only git, gh, grep, cat, ls, etc.); restricted gh-issue-only for Consultant; denylist for Dev (no force push, hard reset, push to main/master). Parses pipes, `&&`, `;`, and `$(...)` subshells.
- Updated CLAUDE.md to remove "planned" note and reflect current file structure

Agent frontmatter already references these hooks — no agent def changes needed.

Closes #10

## Test plan

- [x] 51 tests pass (`bash scripts/hooks/tests/test-hooks.sh`)
- [ ] Manual integration: invoke TPM, attempt write to `src/` — should be blocked
- [ ] Manual integration: invoke Consultant, attempt `git status` — should be blocked
- [ ] Manual integration: invoke Dev, attempt `git push --force` — should be blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)