### PR TITLE
feat(INFRA-011): dev-in base container image with GHCR publish

### DIFF
--- a/.github/workflows/dev-in-image.yml
+++ b/.github/workflows/dev-in-image.yml
@@ -1,0 +1,65 @@
+# Build and publish the dev-in base image to GHCR (INFRA-011).
+#
+# Versioning: every main-branch build pushes :sha-<short> and :edge;
+# tags matching dev-in-v* additionally push the semver tag and :latest.
+name: dev-in image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "infra/dev-in/**"
+      - ".github/workflows/dev-in-image.yml"
+    tags:
+      - "dev-in-v*"
+  workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/ai-lindale-dev-in
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=edge,enable={{is_default_branch}}
+            type=match,pattern=dev-in-v(.*),group=1
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/dev-in-v') }}
+
+      - name: Build (single-arch) and smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: infra/dev-in
+          load: true
+          tags: ${{ env.IMAGE }}:smoke
+
+      - name: Smoke test
+        run: bash infra/dev-in/smoke-test.sh ${{ env.IMAGE }}:smoke
+
+      - name: Build multi-arch and push
+        uses: docker/build-push-action@v6
+        with:
+          context: infra/dev-in
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docs/dev-in.md
+++ b/docs/dev-in.md
@@ -1,0 +1,92 @@
+# dev-in: the Lindalë base container image
+
+The dev-in image is the L4 foundation of the container-as-boundary architecture
+(EPIC-004, #69). Claude Code runs inside the container with full permissions —
+no hooks, no sandbox — because the container IS the security boundary.
+Credentials are injected at the network layer by [moat](https://github.com/majorcontext/moat),
+so tokens never enter the agent's environment.
+
+## What's in the image
+
+| Component | Source | Pinning |
+|-----------|--------|---------|
+| Ubuntu 24.04 | Docker Hub official | base tag |
+| Claude Code | `claude.ai/install.sh` (Anthropic first-party) | `CLAUDE_CODE_CHANNEL` build arg (default `stable`) |
+| Node.js LTS | nodejs.org dist tarball | `NODE_VERSION` build arg |
+| gh CLI | github.com/cli/cli release tarball | `GH_VERSION` build arg |
+| git, python3, jq, ripgrep, curl, sudo | Ubuntu archive | apt |
+
+Supply chain policy: **first-party installs only** — no npm -g, no third-party
+apt repos. Runs as non-root user `dev` (uid 1000) with passwordless sudo;
+repos live under `/home/dev/work`.
+
+## Pull and run standalone
+
+```bash
+docker pull ghcr.io/grinnellian/ai-lindale-dev-in:edge
+
+# Interactive shell
+docker run -it ghcr.io/grinnellian/ai-lindale-dev-in:edge
+
+# Straight into Claude Code (log in via browser OAuth on first run)
+docker run -it ghcr.io/grinnellian/ai-lindale-dev-in:edge claude
+```
+
+Phase-0-style bootstrap (no moat yet — token as env var, acceptable only for
+local single-user use):
+
+```bash
+docker run -it -e GH_TOKEN="$(gh auth token)" \
+  ghcr.io/grinnellian/ai-lindale-dev-in:edge
+```
+
+## Running under moat
+
+Moat generates a **per-host CA** for its TLS-intercepting proxy, so the cert
+is not baked into the published image. The entrypoint trusts whatever is
+mounted at `/run/moat/moat-ca.crt` (override the path with `MOAT_CA_CERT`):
+
+```bash
+docker run -it \
+  -v "$HOME/.moat/certs/ca.crt:/run/moat/moat-ca.crt:ro" \
+  -e HTTPS_PROXY=http://host.docker.internal:8080 \
+  ghcr.io/grinnellian/ai-lindale-dev-in:edge
+```
+
+(The exact mount path and proxy port depend on your moat configuration; when
+the `lindale` CLI lands in M2 it wires this automatically via `moat run`.)
+
+With no CA mounted the entrypoint is a no-op, so the image works identically
+with or without moat.
+
+## Build locally
+
+```bash
+bash infra/dev-in/build.sh                # → ghcr.io/grinnellian/ai-lindale-dev-in:dev
+bash infra/dev-in/smoke-test.sh           # verify the build
+```
+
+Version overrides:
+
+```bash
+docker build \
+  --build-arg NODE_VERSION=24.18.0 \
+  --build-arg GH_VERSION=2.96.0 \
+  --build-arg CLAUDE_CODE_CHANNEL=stable \
+  -t ai-lindale-dev-in:custom infra/dev-in
+```
+
+## Publishing and versioning
+
+CI (`.github/workflows/dev-in-image.yml`) builds on every main-branch change
+to `infra/dev-in/`, smoke-tests, and pushes multi-arch (amd64 + arm64) to
+`ghcr.io/grinnellian/ai-lindale-dev-in`:
+
+- `:sha-<short>` — every build (immutable)
+- `:edge` — latest main build
+- `:<semver>` + `:latest` — on `dev-in-v*` tags
+
+## Size budget
+
+Target **<1.5GB**, hard ceiling **2GB** (smoke test enforces the ceiling and
+warns over target).

--- a/infra/dev-in/Dockerfile
+++ b/infra/dev-in/Dockerfile
@@ -1,0 +1,78 @@
+# syntax=docker/dockerfile:1
+# Lindalë dev-in base image (INFRA-011, EPIC-004 L4).
+#
+# The container IS the security boundary: Claude Code runs inside with full
+# permissions, and moat injects credentials at the network layer so tokens
+# never enter the agent's environment.
+#
+# Supply chain policy: first-party installs only. No npm -g, no third-party
+# apt repos, no convenience mirrors. Node and gh come from their vendors'
+# release artifacts; Claude Code from Anthropic's official installer.
+#
+# Moat CA: moat generates a per-host CA, so it CANNOT be baked into a
+# published image. The entrypoint trusts a CA mounted at /run/moat/moat-ca.crt
+# (override path with MOAT_CA_CERT). See docs/dev-in.md.
+
+FROM ubuntu:24.04
+
+ARG NODE_VERSION=24.18.0
+ARG GH_VERSION=2.96.0
+# stable | latest | an exact Claude Code version number
+ARG CLAUDE_CODE_CHANNEL=stable
+ARG TARGETARCH
+
+# Base tooling
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      ca-certificates curl wget git jq ripgrep sudo unzip xz-utils \
+      python3 python3-pip python3-venv \
+      openssl less nano vim-tiny \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node.js LTS — first-party dist tarball from nodejs.org
+RUN case "${TARGETARCH}" in \
+      amd64) NODE_ARCH=x64 ;; \
+      arm64) NODE_ARCH=arm64 ;; \
+      *) echo "unsupported arch: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" -o /tmp/node.tar.xz \
+    && tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 --no-same-owner \
+    && rm /tmp/node.tar.xz \
+    && node --version
+
+# gh CLI — first-party release tarball from github.com/cli/cli
+RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${TARGETARCH}.tar.gz" -o /tmp/gh.tar.gz \
+    && tar -xzf /tmp/gh.tar.gz -C /tmp \
+    && install -m 755 "/tmp/gh_${GH_VERSION}_linux_${TARGETARCH}/bin/gh" /usr/local/bin/gh \
+    && rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_VERSION}_linux_${TARGETARCH}" \
+    && gh --version
+
+# Non-root dev user with passwordless sudo (interactive package installs).
+# ubuntu:24.04 ships a default 'ubuntu' user at uid 1000 — remove it so
+# 'dev' takes the conventional uid.
+RUN userdel -r ubuntu 2>/dev/null || true \
+    && useradd -m -s /bin/bash -u 1000 dev \
+    && echo 'dev ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/dev \
+    && chmod 440 /etc/sudoers.d/dev
+
+COPY entrypoint.sh /usr/local/bin/dev-in-entrypoint
+RUN chmod 755 /usr/local/bin/dev-in-entrypoint
+
+USER dev
+WORKDIR /home/dev
+
+# Claude Code — Anthropic's official installer, into ~/.local/bin
+RUN curl -fsSL https://claude.ai/install.sh | bash -s -- "${CLAUDE_CODE_CHANNEL}" \
+    && echo 'export PATH="$HOME/.local/bin:$PATH"' >> /home/dev/.bashrc
+
+ENV PATH="/home/dev/.local/bin:${PATH}"
+
+# Git defaults: any mounted/cloned repo is trusted inside the boundary
+RUN git config --global safe.directory '*' \
+    && git config --global init.defaultBranch main
+
+# Workdir convention: repos are cloned or mounted under /home/dev/work
+RUN mkdir -p /home/dev/work
+WORKDIR /home/dev/work
+
+ENTRYPOINT ["/usr/local/bin/dev-in-entrypoint"]
+CMD ["bash"]

--- a/infra/dev-in/build.sh
+++ b/infra/dev-in/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Local build entry for the dev-in image (INFRA-011).
+# Usage: bash infra/dev-in/build.sh [tag]
+set -euo pipefail
+
+TAG="${1:-ghcr.io/grinnellian/ai-lindale-dev-in:dev}"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+docker build -t "$TAG" "$DIR"
+echo ""
+echo "Built $TAG"
+docker image inspect "$TAG" --format 'Size: {{.Size}} bytes'

--- a/infra/dev-in/entrypoint.sh
+++ b/infra/dev-in/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# dev-in entrypoint: trust the moat CA if one is mounted, then exec the command.
+#
+# Moat generates a per-host CA for its TLS-intercepting proxy, so the cert
+# cannot be baked into a published image. Mount it read-only at
+# /run/moat/moat-ca.crt (or point MOAT_CA_CERT at another path):
+#
+#   docker run -v "$HOME/.moat/certs/ca.crt:/run/moat/moat-ca.crt:ro" ...
+#
+# Running without moat (e.g. Phase-0-style GH_TOKEN bootstrap) is fine —
+# the CA step is skipped silently.
+set -euo pipefail
+
+CA_SRC="${MOAT_CA_CERT:-/run/moat/moat-ca.crt}"
+if [ -f "$CA_SRC" ]; then
+  sudo install -m 644 "$CA_SRC" /usr/local/share/ca-certificates/moat-ca.crt
+  sudo update-ca-certificates >/dev/null
+  # Node-based tools keep their own trust store
+  export NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/moat-ca.crt
+fi
+
+exec "$@"

--- a/infra/dev-in/smoke-test.sh
+++ b/infra/dev-in/smoke-test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Smoke test for the dev-in image (INFRA-011).
+# Usage: bash infra/dev-in/smoke-test.sh [tag]
+set -euo pipefail
+
+TAG="${1:-ghcr.io/grinnellian/ai-lindale-dev-in:dev}"
+PASS=0
+FAIL=0
+
+check() {
+  local name="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "  PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== dev-in smoke test: $TAG ==="
+
+# Tooling present and runnable
+check "claude --version"  docker run --rm "$TAG" claude --version
+check "git --version"     docker run --rm "$TAG" git --version
+check "node --version"    docker run --rm "$TAG" node --version
+check "python3 --version" docker run --rm "$TAG" python3 --version
+check "gh --version"      docker run --rm "$TAG" gh --version
+check "jq --version"      docker run --rm "$TAG" jq --version
+check "rg --version"      docker run --rm "$TAG" rg --version
+
+# Runs as non-root dev user with sudo
+check "runs as dev user"  bash -c "[ \"\$(docker run --rm $TAG whoami)\" = dev ]"
+check "sudo works"        docker run --rm "$TAG" sudo true
+
+# Git defaults
+check "safe.directory=*"  bash -c "docker run --rm $TAG git config --global safe.directory | grep -qx '\*'"
+
+# Moat CA: mount a throwaway CA, entrypoint must install it into the trust store
+CA_TMP=$(mktemp -d)
+trap 'rm -rf "$CA_TMP"' EXIT
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+  -keyout "$CA_TMP/ca.key" -out "$CA_TMP/ca.crt" \
+  -subj "/CN=moat-smoke-test-ca" >/dev/null 2>&1
+check "moat CA trusted when mounted" bash -c \
+  "docker run --rm -v '$CA_TMP/ca.crt:/run/moat/moat-ca.crt:ro' $TAG \
+     openssl x509 -in /usr/local/share/ca-certificates/moat-ca.crt -noout -subject \
+   | grep -q moat-smoke-test-ca"
+check "no CA mounted -> starts clean" bash -c \
+  "docker run --rm $TAG bash -c '[ ! -f /usr/local/share/ca-certificates/moat-ca.crt ]'"
+
+# Size budget: target <1.5GB, hard ceiling 2GB
+SIZE=$(docker image inspect "$TAG" --format '{{.Size}}')
+SIZE_GB=$(python3 -c "print(f'{$SIZE/1024**3:.2f}')")
+if [ "$SIZE" -lt 2147483648 ]; then
+  echo "  PASS: image size ${SIZE_GB}GB under 2GB hard ceiling"
+  PASS=$((PASS + 1))
+  [ "$SIZE" -ge 1610612736 ] && echo "  WARN: over the 1.5GB target"
+else
+  echo "  FAIL: image size ${SIZE_GB}GB exceeds 2GB hard ceiling"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #83. EPIC-004 (#69) L4, M1: Moat Foundation.

## What

- `infra/dev-in/Dockerfile` — ubuntu:24.04; Claude Code via Anthropic's official installer (`CLAUDE_CODE_CHANNEL` arg, default stable); Node 24 LTS and gh CLI pinned via build args from **first-party release artifacts only** (supply-chain policy from the Phase 0 bootstrap notes); python3, jq, ripgrep; non-root `dev` user (uid 1000) with passwordless sudo; `git safe.directory '*'`; workdir `/home/dev/work`
- `entrypoint.sh` — trusts a moat CA mounted at `/run/moat/moat-ca.crt` at container start (plus `NODE_EXTRA_CA_CERTS`); silent no-op without moat, so Phase-0-style `GH_TOKEN` bootstrap still works
- `build.sh` / `smoke-test.sh` — local entry points; 13 smoke checks including mounted-CA trust verification and size ceiling
- `.github/workflows/dev-in-image.yml` — smoke-test gate, then multi-arch (amd64+arm64) push to `ghcr.io/grinnellian/ai-lindale-dev-in` (`:sha-*` immutable, `:edge` on main, semver + `:latest` on `dev-in-v*` tags)
- `docs/dev-in.md` — pull/run standalone, moat mount, build args, versioning, size budget

## Architect callouts (per issue)

- **Moat CA baked vs mounted**: the issue's AC said "moat CA pre-trusted in image", but moat generates a **per-host CA** — baking one into a published image is impossible (and would be a shared-key anti-pattern). Resolved as runtime trust-on-mount in the entrypoint; the smoke test verifies the mechanism with a throwaway CA. No vendor-moat ticket needed for this: per the EPIC sequencing update, M1/M2 use moat as-is and vendoring moved to M3+.
- **VS Code** deliberately not baked: L2 decision is Claude Code Remote Control as primary UI; keeps the image at 0.22GB vs the multi-GB Phase 0 bootstrap container.

## Verification

- Local arm64 build clean; smoke test **13/13** (tools, non-root user, sudo, git config, CA mount, size)
- Image **0.22GB** (target <1.5GB, ceiling 2GB)
- Claude Code 2.1.193, node v24.18.0, gh 2.96.0, python 3.12.3
- Remaining AC on merge: CI publishes to GHCR (workflow triggers on main-branch changes to `infra/dev-in/**`); one interactive `docker run -it … claude` OAuth login is a human verification step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vPzUYejTmwX7BuSZNfbtZ