### PR TITLE
feat(FEAT-018): trampollm v1 — continuation trampoline with BATON v1 contract (#108)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,6 @@ jobs:
 
       - name: Install / adoption tests
         run: bash scripts/tests/test-adoption.sh
+
+      - name: trampollm tests (FEAT-018)
+        run: bash scripts/tests/test-trampollm.sh

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@
 
 # Self-referencing submodule (dev testing, not part of the product)
 .ai-lindale/
+
+# trampollm (FEAT-018) raw run artifacts. The baton chain and TRIPPED.md are
+# the audit trail and stay tracked; raw model JSON and per-bounce stderr are
+# unbounded, may echo prompt/tool content, and must not drift into a commit.
+memory/trampoline/*/*-response.json
+memory/trampoline/*/*-stderr.log

--- a/docs/baton.md
+++ b/docs/baton.md
@@ -96,11 +96,29 @@ concepts rhyme, but is deliberately not the same contract as either:
 
 Every baton is written verbatim to
 `memory/trampoline/<run-id>/NNN-baton.md` (zero-padded, one file per bounce)
-— the chain of these files is the audit trail. When a rail trips
-(`--max-bounces`, cumulative `--max-cost-usd`, identical-baton loop
-detection, exhausted error retries, or an unrecoverable malformed baton),
-the trampoline writes `memory/trampoline/<run-id>/TRIPPED.md` containing the
-rail name, bounce count, cumulative cost, and the last good baton verbatim —
-the resume path is feeding that block back in as a fresh `--prompt`. If
-`ticket:` is known (from `--ticket` or supplied by the baton itself), the
-trip also posts an issue comment and adds the `needs-human` label.
+— the chain of these files is the audit trail. Alongside them the trampoline
+keeps each bounce's raw response JSON and stderr (`NNN-response.json`,
+`NNN-stderr.log`); a dispatch that failed and was retried is preserved under
+`NNN-attemptK-*` so the retry cannot overwrite the evidence of what went
+wrong. Those raw files are gitignored — the batons are the tracked record.
+
+When a rail trips (`--max-bounces`, cumulative `--max-cost-usd`,
+identical-baton loop detection, exhausted error retries, or an unrecoverable
+malformed baton), the trampoline writes
+`memory/trampoline/<run-id>/TRIPPED.md` containing the rail name, bounce
+count, cumulative cost, and the last good baton verbatim — the resume path is
+feeding that block back in as a fresh `--prompt`. If `ticket:` is known (from
+`--ticket` or supplied by the baton itself), the trip also posts an issue
+comment and adds the `needs-human` label; a failure to post is reported on
+stderr rather than swallowed, since that comment is the page to a human.
+
+Cost accounting counts **every** dispatch, not only the one whose baton was
+accepted: a bounce that errors after doing work is still a billed run, so
+failed attempts are summed into the cumulative total and the cap is
+re-checked between retries.
+
+Per-bounce issue comments are available opt-in via `--comment-bounces`, using
+the same `--body-file` pattern as escalation. It requires a `--ticket` passed
+on the command line: a `ticket:` adopted out of a baton is model-authored,
+and a write per bounce aimed at a model-chosen issue should be a deliberate
+operator choice.

--- a/docs/baton.md
+++ b/docs/baton.md
@@ -1,0 +1,106 @@
+# BATON v1
+
+A light, machine-greppable handoff contract for continuation trampolines
+(`scripts/trampollm.sh`, FEAT-018) that chain fresh `claude -p` invocations
+into a multi-bounce relay. Findings that motivated this shape came from the
+FEAT-017 spike (#107) — see that issue for the empirical background.
+
+This is a standalone schema doc: downstream tickets can cite BATON v1
+without depending on the trampoline script itself.
+
+## The block
+
+A baton is a fenced block of `key: value` lines, emitted as the tail of a
+bounce's final message:
+
+```
+--- BATON v1 ---
+status: CONTINUE | DONE | PARK | ESCALATE
+goal: <one line, copied verbatim from the previous baton — stable across bounces>
+ticket: #NNN
+next-agent: dev | architect | tpm | <same>
+done-criteria: <how the chain knows to emit DONE>
+state: <what is now true: branch, commits, tests green/red; may point at a tracker file>
+next-step: <the successor's first action — imperative>
+breadcrumbs: <tried-and-failed, gotchas; "none" allowed>
+--- END BATON ---
+```
+
+Why this shape (not free text, not full JSON): fenced key/value is
+machine-greppable, human-readable when posted in an issue comment (glass
+walls), and robust to an LLM's tendency to paraphrase — the FEAT-017 spike
+observed 7/7 trials reproducing the sentinel fence verbatim when the wrapping
+prompt demanded it explicitly. The prompt contract is part of the utility,
+not optional: a relay only works because every bounce is instructed to end
+with a complete block.
+
+## Field requirements
+
+| Field | Requirement | Notes |
+|---|---|---|
+| `--- BATON v1 ---` / `--- END BATON ---` fence | **Hard** | The sentinel a trampoline parses on. Emit exactly one block; if more than one appears, the last is used. |
+| `status:` | **Hard** | One of `CONTINUE \| DONE \| PARK \| ESCALATE`. Case-insensitive by convention; trampolines uppercase before dispatch. |
+| `goal:` | contract-by-convention | Copied verbatim bounce-to-bounce so drift is visible. |
+| `ticket:` | contract-by-convention | `#NNN`. When present, a trampoline can auto-adopt it for escalation even if not passed on the CLI. |
+| `next-agent:` | contract-by-convention | Persona for the next bounce. `<same>` (or empty) keeps the current agent. |
+| `done-criteria:` | contract-by-convention | How the chain recognizes it should emit `DONE`. |
+| `state:` | contract-by-convention | What is now true — may be a pointer into a durable ledger rather than a restatement of it (see DX-038 below). |
+| `next-step:` | contract-by-convention | The successor's first action, written as an imperative. |
+| `breadcrumbs:` | contract-by-convention | Tried-and-failed attempts, gotchas. `"none"` is a valid value. Excluded from the loop-detection hash (see below) so breadcrumb-only edits don't count as forward progress, and can't mask a genuine repeat either. |
+
+Only the fence and `status:` are enforced by the trampoline loop itself; the
+remaining fields are enforced by the wrapping relay prompt (contract-by-convention),
+not by a parser. A trampoline that receives a reply without a valid fence
+and `status:` treats it as a malformed baton — one corrective re-prompt, then
+a trip (see `scripts/trampollm.sh`'s exit code table).
+
+## Status vocabulary
+
+| Status | Meaning |
+|---|---|
+| `CONTINUE` | Another bounce picks up this baton verbatim as its seed context. |
+| `DONE` | The relay terminates successfully (trampoline exit 0). |
+| `PARK` | The relay stops; a human is notified (trampoline exit 2). |
+| `ESCALATE` | The relay stops; a human is notified (trampoline exit 2). Distinct from `PARK` in intent — `PARK` implies "resumable later," `ESCALATE` implies "needs a decision" — but a trampoline handles both identically today. |
+
+## Identity and signing
+
+Batons are **unsigned by design**. A human-facing handoff (see FEAT-013
+below) carries a signature because a person is accountable for it; a baton
+is machine-to-machine, and its identity is the `next-agent:` routing field,
+not a signature block.
+
+## Relations to neighboring contracts
+
+BATON v1 shares field *names* with two other in-flight conventions where the
+concepts rhyme, but is deliberately not the same contract as either:
+
+- **DX-038 memory state tracker (#89) — shared subset + pointer, not the
+  same contract.** The tracker is the durable ledger; the baton is the
+  in-flight message carrying a delta and a pointer into it (`state:`). Never
+  duplicate the ledger in a baton — the baton is the entire seed context for
+  the next fresh window, so it must stay small.
+- **FEAT-013 handoff (#62) — deliberately separate.** The handoff is
+  human-facing, prose, and signed; the baton is machine-to-machine, emitted
+  per-bounce, and unsigned. `goal`/`state`/`next-step` are shared field
+  names so the concepts rhyme across the two documents; nothing else is
+  shared.
+- **EPIC-005 k10s task ticket (#70) — superset candidate.**
+  `goal`/`status`/`ticket`/`breadcrumbs` map onto k10s's
+  `description`/`context`/`ticket_id`; a k10s task ticket would add
+  `signature`, `budget`, and `additional_endpoints` on top. BATON v1 is
+  designed so those fields can be added without renaming anything already
+  here. No dependency in either direction as of v1.
+
+## Observability
+
+Every baton is written verbatim to
+`memory/trampoline/<run-id>/NNN-baton.md` (zero-padded, one file per bounce)
+— the chain of these files is the audit trail. When a rail trips
+(`--max-bounces`, cumulative `--max-cost-usd`, identical-baton loop
+detection, exhausted error retries, or an unrecoverable malformed baton),
+the trampoline writes `memory/trampoline/<run-id>/TRIPPED.md` containing the
+rail name, bounce count, cumulative cost, and the last good baton verbatim —
+the resume path is feeding that block back in as a fresh `--prompt`. If
+`ticket:` is known (from `--ticket` or supplied by the baton itself), the
+trip also posts an issue comment and adds the `needs-human` label.

--- a/scripts/tests/test-trampollm.sh
+++ b/scripts/tests/test-trampollm.sh
@@ -39,6 +39,9 @@ n=$(cat "$STUB_DIR/counter" 2>/dev/null || echo 0); n=$((n+1))
 printf '%s\n' "$n" > "$STUB_DIR/counter"
 printf '%s\n' "$*" >> "$STUB_DIR/calls.log"
 printf '%s\n' "---END-CALL---" >> "$STUB_DIR/calls.log"
+if [ -f "$STUB_DIR/response_${n}.stderr" ]; then
+  cat "$STUB_DIR/response_${n}.stderr" >&2
+fi
 cat "$STUB_DIR/response_${n}.json" 2>/dev/null
 exit "$(cat "$STUB_DIR/response_${n}.exit" 2>/dev/null || echo 0)"
 STUB
@@ -84,6 +87,13 @@ fixture_error() {
     '{result: $result, session_id: "sess-test", total_cost_usd: $cost, is_error: true, subtype: "success", terminal_reason: "api_error", num_turns: 1}' \
     >"$STUB_DIR/response_${n}.json"
   printf '%s\n' "$exit_code" >"$STUB_DIR/response_${n}.exit"
+}
+
+# fixture_stderr <n> <text> — the stub claude will emit <text> on stderr
+# for call N (in addition to whatever fixture_ok/fixture_error set up).
+fixture_stderr() {
+  local n="$1" text="$2"
+  printf '%s\n' "$text" >"$STUB_DIR/response_${n}.stderr"
 }
 
 # --- Assertions ---
@@ -186,6 +196,25 @@ run_trampollm() {
   set -e
 }
 
+# run_trampollm_no_gh [args...] — like run_trampollm, but PATH contains ONLY
+# a bin/ dir with claude (no gh stub, no fallback to the real system PATH),
+# so `command -v gh` is guaranteed to fail deterministically and — even if
+# the guard were buggy — no real `gh` binary could ever be reached. Sets $rc.
+run_trampollm_no_gh() {
+  local nogh_bin="$PROJECT/nogh-bin"
+  mkdir -p "$nogh_bin"
+  cp "$PROJECT/bin/claude" "$nogh_bin/claude"
+  # jq is a real dependency (require_jq), so copy the real binary in --
+  # deliberately NOT adding its directory to PATH, since that directory
+  # may also contain a real `gh` (defeating the point of this harness).
+  cp -L "$(command -v jq)" "$nogh_bin/jq"
+  set +e
+  PATH="$nogh_bin" TRAMPOLLM_BACKOFF_BASE=0 \
+    bash "$TRAMPOLLM" "$@" --run-id test-run >"$PROJECT/stdout.log" 2>"$PROJECT/stderr.log"
+  rc=$?
+  set -e
+}
+
 RUN_DIR="memory/trampoline/test-run"
 
 # ===========================================================================
@@ -277,6 +306,46 @@ test_hash_differs_on_next_step_change() {
 }
 
 # ===========================================================================
+# Phase 1b — CLI arg-parser safety (value-less trailing flags)
+# ===========================================================================
+
+# Every value-taking flag trampollm.sh accepts. -h/--help takes no value and
+# is deliberately excluded.
+VALUE_TAKING_FLAGS="--prompt --agent --max-bounces --max-turns --max-budget-usd --max-cost-usd --retries --ticket --run-id --model"
+
+# test_arg_parser_valueless_trailing_flag_exits_1 — a value-less flag as the
+# LAST argument (e.g. `trampollm.sh --prompt`) must fail fast with exit 1 and
+# a non-empty stderr message, never hang. Reproduces the architect's repro
+# for every value-taking flag, not just --prompt. Wrapped in `timeout` so a
+# regression fails fast in CI instead of hanging the suite.
+test_arg_parser_valueless_trailing_flag_exits_1() {
+  setup_project
+  local flag frc failed=0
+  for flag in $VALUE_TAKING_FLAGS; do
+    set +e
+    PATH="$PROJECT/bin:$PATH" TRAMPOLLM_BACKOFF_BASE=0 \
+      timeout 5 bash "$TRAMPOLLM" "$flag" >"$PROJECT/stdout.log" 2>"$PROJECT/stderr.log"
+    frc=$?
+    set -e
+    if [ "$frc" -eq 124 ]; then
+      echo "    flag $flag: timed out under timeout(1) -- hang detected"
+      failed=1
+      continue
+    fi
+    if [ "$frc" -ne 1 ]; then
+      echo "    flag $flag: expected exit 1, got $frc"
+      failed=1
+      continue
+    fi
+    if [ ! -s "$PROJECT/stderr.log" ]; then
+      echo "    flag $flag: expected non-empty stderr, got none"
+      failed=1
+    fi
+  done
+  [ "$failed" -eq 0 ]
+}
+
+# ===========================================================================
 # Phase 2 — single bounce & the is_error gotcha
 # ===========================================================================
 
@@ -306,12 +375,25 @@ test_is_error_gates_before_result() {
 test_is_error_gotcha_ignores_subtype_success() {
   setup_project
   # exit 1, is_error:true, but subtype stays "success" — the FEAT-017 gotcha.
+  # --retries 0 = zero retries after the initial attempt = 1 total dispatch.
   fixture_error 1 "misleading prose" 1 0
-  run_trampollm --prompt "do the thing" --retries 1
+  run_trampollm --prompt "do the thing" --retries 0
   assert_eq 1 "$rc" "exit code" &&
   assert_file_exists "$RUN_DIR/TRIPPED.md" &&
   assert_file_contains "$RUN_DIR/TRIPPED.md" "rail: error" &&
   assert_call_count "$STUB_DIR/calls.log" 1
+}
+
+test_stderr_captured_to_run_dir_not_discarded() {
+  setup_project
+  fixture_ok 1 "work done.
+
+$(baton_block DONE final)" 0.01
+  fixture_stderr 1 "diagnostic breadcrumb: warming cache, retrying internal fetch"
+  run_trampollm --prompt "do the thing"
+  assert_eq 0 "$rc" "exit code" &&
+  assert_file_exists "$RUN_DIR/001-stderr.log" &&
+  assert_file_contains "$RUN_DIR/001-stderr.log" "diagnostic breadcrumb: warming cache, retrying internal fetch"
 }
 
 # ===========================================================================
@@ -438,6 +520,28 @@ $(baton_block CONTINUE same-step)" 0.01
   assert_file_contains "$RUN_DIR/TRIPPED.md" "rail: loop-detected"
 }
 
+test_identical_baton_corrective_reprompt_then_recovers() {
+  setup_project
+  fixture_ok 1 "bounce one.
+
+$(baton_block CONTINUE same-step)" 0.01
+  fixture_ok 2 "bounce two, identical.
+
+$(baton_block CONTINUE same-step)" 0.01
+  fixture_ok 3 "bounce three, changed after correction.
+
+$(baton_block CONTINUE different-step)" 0.01
+  fixture_ok 4 "bounce four, done.
+
+$(baton_block DONE final-step)" 0.01
+  run_trampollm --prompt "start"
+  assert_eq 0 "$rc" "exit code" &&
+  assert_call_count "$STUB_DIR/calls.log" 4 &&
+  assert_call_contains "$STUB_DIR/calls.log" 3 "Identical baton detected" &&
+  assert_file_exists "$RUN_DIR/004-baton.md" &&
+  assert_file_not_exists "$RUN_DIR/TRIPPED.md"
+}
+
 test_error_retry_with_backoff_then_success() {
   setup_project
   fixture_error 1 "transient error" 1 0
@@ -452,13 +556,23 @@ $(baton_block DONE recovered)" 0.01
 
 test_error_retries_exhausted_trips() {
   setup_project
+  # --retries N means N retries AFTER the initial attempt -> N+1 total
+  # dispatches. --retries 3 => 1 initial + 3 retries = 4 total calls.
   fixture_error 1 "transient error" 1 0
   fixture_error 2 "transient error" 1 0
   fixture_error 3 "transient error" 1 0
+  fixture_error 4 "transient error" 1 0
   run_trampollm --prompt "start" --retries 3
   assert_eq 1 "$rc" "exit code" &&
-  assert_call_count "$STUB_DIR/calls.log" 3 &&
+  assert_call_count "$STUB_DIR/calls.log" 4 &&
   assert_file_contains "$RUN_DIR/TRIPPED.md" "rail: error"
+}
+
+test_help_text_describes_retries_as_after_initial_attempt() {
+  local out
+  out="$(bash "$TRAMPOLLM" --help)"
+  printf '%s' "$out" | grep -qi "retries" || { echo "    --help missing 'retries': $out"; return 1; }
+  printf '%s' "$out" | grep -qi "after the initial attempt" || { echo "    --help does not clarify N retries are AFTER the initial attempt: $out"; return 1; }
 }
 
 test_malformed_baton_one_correction_then_trip() {
@@ -469,6 +583,22 @@ test_malformed_baton_one_correction_then_trip() {
   assert_eq 1 "$rc" "exit code" &&
   assert_call_contains "$STUB_DIR/calls.log" 2 "no valid BATON v1 block" &&
   assert_file_contains "$RUN_DIR/TRIPPED.md" "rail: malformed-baton"
+}
+
+test_malformed_baton_corrective_reprompt_then_recovers() {
+  setup_project
+  fixture_ok 1 "no baton block in this reply at all." 0.01
+  fixture_ok 2 "recovered, done.
+
+$(baton_block DONE recovered-after-correction)" 0.01
+  run_trampollm --prompt "start"
+  assert_eq 0 "$rc" "exit code" &&
+  assert_call_count "$STUB_DIR/calls.log" 2 &&
+  assert_call_contains "$STUB_DIR/calls.log" 2 "no valid BATON v1 block" &&
+  assert_file_not_exists "$RUN_DIR/001-baton.md" &&
+  assert_file_exists "$RUN_DIR/002-baton.md" &&
+  assert_file_contains "$RUN_DIR/002-baton.md" "status: DONE" &&
+  assert_file_not_exists "$RUN_DIR/TRIPPED.md"
 }
 
 test_status_park_trips() {
@@ -539,6 +669,17 @@ $(baton_block CONTINUE step1 '<same>' '')" 0.01
   assert_file_not_exists "$STUB_DIR/gh.log"
 }
 
+test_escalation_degrades_gracefully_without_gh() {
+  setup_project
+  fixture_ok 1 "bounce one.
+
+$(baton_block CONTINUE step1)" 0.01
+  run_trampollm_no_gh --prompt "start" --max-bounces 1 --ticket 108
+  assert_eq 3 "$rc" "exit code" &&
+  assert_file_exists "$RUN_DIR/TRIPPED.md" &&
+  assert_file_contains "$PROJECT/stderr.log" "gh not found; skipping escalation"
+}
+
 # --- Run all tests ---
 
 echo "=== FEAT-018 trampollm Tests ==="
@@ -552,10 +693,14 @@ run_test "baton_field/baton_status whitespace-tolerant" test_baton_field_whitesp
 run_test "hash_baton stable across breadcrumbs-only diff" test_normalize_hash_stable_across_breadcrumbs
 run_test "hash_baton differs on next-step change" test_hash_differs_on_next_step_change
 echo ""
+echo "--- phase 1b: CLI arg-parser safety ---"
+run_test "value-less trailing flag exits 1 (never hangs), for every value-taking flag" test_arg_parser_valueless_trailing_flag_exits_1
+echo ""
 echo "--- phase 2: single bounce & is_error gotcha ---"
 run_test "clean single bounce DONE -> exit 0, writes 001-baton.md" test_clean_single_bounce_done
 run_test "is_error gates before .result is dispatched" test_is_error_gates_before_result
 run_test "gotcha: is_error true + subtype success still trips as error" test_is_error_gotcha_ignores_subtype_success
+run_test "per-bounce stderr captured to run dir, not discarded" test_stderr_captured_to_run_dir_not_discarded
 echo ""
 echo "--- phase 3: multi-bounce loop ---"
 run_test "sentinel termination: 3 CONTINUE then DONE -> exit 0" test_sentinel_termination_three_continue_then_done
@@ -567,9 +712,12 @@ echo "--- phase 4: rails ---"
 run_test "--max-bounces trip -> exit 3" test_max_bounces_trip
 run_test "cumulative cost trip checked before dispatch -> exit 5" test_cumulative_cost_trip_before_dispatch
 run_test "identical-baton loop detection -> exit 4" test_identical_baton_loop_detection
+run_test "identical-baton corrective re-prompt then recovers -> exit 0" test_identical_baton_corrective_reprompt_then_recovers
 run_test "error retry with backoff then success -> exit 0" test_error_retry_with_backoff_then_success
-run_test "error retries exhausted -> exit 1" test_error_retries_exhausted_trips
+run_test "error retries exhausted (N retries after initial = N+1 total) -> exit 1" test_error_retries_exhausted_trips
+run_test "--help text documents retries-after-initial-attempt semantics" test_help_text_describes_retries_as_after_initial_attempt
 run_test "malformed baton: one correction then trip -> exit 1" test_malformed_baton_one_correction_then_trip
+run_test "malformed baton: corrective re-prompt then recovers -> exit 0" test_malformed_baton_corrective_reprompt_then_recovers
 run_test "status PARK trips -> exit 2" test_status_park_trips
 run_test "status ESCALATE trips -> exit 2" test_status_escalate_trips
 echo ""
@@ -577,6 +725,7 @@ echo "--- phase 5: trip observability & escalation ---"
 run_test "TRIPPED.md contains rail/bounce/cost/last-baton" test_tripped_md_content
 run_test "escalation posts gh comment + needs-human label when ticket set" test_escalation_with_ticket
 run_test "no gh calls when ticket unset" test_no_escalation_without_ticket
+run_test "escalation degrades gracefully (warns, no crash) when gh is absent" test_escalation_degrades_gracefully_without_gh
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/tests/test-trampollm.sh
+++ b/scripts/tests/test-trampollm.sh
@@ -344,6 +344,65 @@ test_arg_parser_valueless_trailing_flag_exits_1() {
   [ "$failed" -eq 0 ]
 }
 
+# test_arg_parser_rejects_non_numeric_rail_values — a non-numeric value for
+# a rail that the wrapper itself compares (max-bounces, retries: bash `-ge`/
+# `-gt`; max-cost-usd: awk numeric compare) must fail fast with exit 1 and a
+# usage message, never silently disable the rail. Reproduces a review
+# finding: "trampollm.sh --retries abc" against an always-erroring stub used
+# to hang forever (`[ "$attempt" -gt "abc" ]` errors, `if` treats the shell
+# error as false, the retry loop never trips).
+test_arg_parser_rejects_non_numeric_rail_values() {
+  setup_project
+  fixture_ok 1 "irrelevant -- should never be dispatched" 0.01
+  local flag failed=0 frc
+  for flag in --max-bounces --retries --max-cost-usd; do
+    set +e
+    PATH="$PROJECT/bin:$PATH" TRAMPOLLM_BACKOFF_BASE=0 \
+      timeout 5 bash "$TRAMPOLLM" --prompt "start" "$flag" abc --run-id "test-run-$flag" \
+      >"$PROJECT/stdout.log" 2>"$PROJECT/stderr.log"
+    frc=$?
+    set -e
+    if [ "$frc" -eq 124 ]; then
+      echo "    flag $flag abc: timed out under timeout(1) -- rail silently disabled"
+      failed=1
+      continue
+    fi
+    if [ "$frc" -ne 1 ]; then
+      echo "    flag $flag abc: expected exit 1, got $frc"
+      failed=1
+      continue
+    fi
+    if ! grep -qi "requires a non-negative" "$PROJECT/stderr.log"; then
+      echo "    flag $flag abc: expected a usage message on stderr, got: $(cat "$PROJECT/stderr.log")"
+      failed=1
+    fi
+    if [ -d "$RUN_DIR" ] || [ -d "memory/trampoline/test-run-$flag" ]; then
+      echo "    flag $flag abc: dispatched a bounce before rejecting the bad value"
+      failed=1
+    fi
+  done
+  [ "$failed" -eq 0 ]
+}
+
+test_arg_parser_accepts_decimal_cost_values() {
+  local v failed=0
+  for v in 10.00 0.5 .5 5 0; do
+    setup_project
+    fixture_ok 1 "work done.
+
+$(baton_block DONE final)" 0.5
+    run_trampollm --prompt "do the thing" --max-cost-usd "$v"
+    if [ "$v" = "0" ]; then
+      # cumulative cost 0 >= cap 0 trips immediately, before any dispatch.
+      assert_eq 5 "$rc" "exit code for --max-cost-usd $v" || failed=1
+    else
+      assert_eq 0 "$rc" "exit code for --max-cost-usd $v" || failed=1
+    fi
+    teardown
+  done
+  [ "$failed" -eq 0 ]
+}
+
 # ===========================================================================
 # Phase 2 — single bounce & the is_error gotcha
 # ===========================================================================
@@ -694,6 +753,8 @@ run_test "hash_baton differs on next-step change" test_hash_differs_on_next_step
 echo ""
 echo "--- phase 1b: CLI arg-parser safety ---"
 run_test "value-less trailing flag exits 1 (never hangs), for every value-taking flag" test_arg_parser_valueless_trailing_flag_exits_1
+run_test "non-numeric rail values (max-bounces/retries/max-cost-usd) rejected, never silently disabled" test_arg_parser_rejects_non_numeric_rail_values
+run_test "decimal --max-cost-usd values (10.00, 0.5, .5, 5, 0) all accepted" test_arg_parser_accepts_decimal_cost_values
 echo ""
 echo "--- phase 2: single bounce & is_error gotcha ---"
 run_test "clean single bounce DONE -> exit 0, writes 001-baton.md" test_clean_single_bounce_done

--- a/scripts/tests/test-trampollm.sh
+++ b/scripts/tests/test-trampollm.sh
@@ -32,9 +32,13 @@ setup_project() {
   cat >bin/claude <<'STUB'
 #!/usr/bin/env bash
 # stub claude — emits canned JSON per invocation, logs args, zero API spend.
+# Args (notably --prompt) may contain embedded newlines, so each call's args
+# are followed by a delimiter line -- callers must split calls.log on it
+# rather than assuming "one call == one line".
 n=$(cat "$STUB_DIR/counter" 2>/dev/null || echo 0); n=$((n+1))
 printf '%s\n' "$n" > "$STUB_DIR/counter"
 printf '%s\n' "$*" >> "$STUB_DIR/calls.log"
+printf '%s\n' "---END-CALL---" >> "$STUB_DIR/calls.log"
 cat "$STUB_DIR/response_${n}.json" 2>/dev/null
 exit "$(cat "$STUB_DIR/response_${n}.exit" 2>/dev/null || echo 0)"
 STUB
@@ -60,7 +64,7 @@ trap teardown EXIT
 
 # baton_block <status> <next_step> [next_agent] [ticket] [breadcrumbs]
 baton_block() {
-  local status="$1" next_step="$2" next_agent="${3:-<same>}" ticket="${4:-#108}" breadcrumbs="${5:-none}"
+  local status="$1" next_step="$2" next_agent="${3:-<same>}" ticket="${4-#108}" breadcrumbs="${5:-none}"
   printf -- '--- BATON v1 ---\nstatus: %s\ngoal: relay test goal\nticket: %s\nnext-agent: %s\ndone-criteria: counter reaches threshold\nstate: in progress\nnext-step: %s\nbreadcrumbs: %s\n--- END BATON ---' \
     "$status" "$ticket" "$next_agent" "$next_step" "$breadcrumbs"
 }
@@ -115,7 +119,7 @@ assert_file_not_exists() {
 
 assert_file_contains() {
   local path="$1" pattern="$2"
-  if grep -qF "$pattern" "$path" 2>/dev/null; then
+  if grep -qF -- "$pattern" "$path" 2>/dev/null; then
     return 0
   else
     echo "    File $path does not contain: $pattern"
@@ -123,24 +127,35 @@ assert_file_contains() {
   fi
 }
 
-assert_line_contains() {
+# calls.log entries are delimited by "---END-CALL---" (args can contain
+# embedded newlines, e.g. --prompt text, so raw line numbers don't map to
+# call numbers).
+
+# call_block <path> <n> — prints the raw args text for call N.
+call_block() {
+  local path="$1" n="$2"
+  awk -v RS='---END-CALL---\n' -v n="$n" 'NR==n { print; exit }' "$path" 2>/dev/null
+}
+
+assert_call_contains() {
   local path="$1" n="$2" pattern="$3"
-  local line
-  line="$(sed -n "${n}p" "$path" 2>/dev/null || true)"
-  if printf '%s' "$line" | grep -qF "$pattern"; then
+  local block
+  block="$(call_block "$path" "$n")"
+  if printf '%s' "$block" | grep -qF -- "$pattern"; then
     return 0
   else
-    echo "    Line $n of $path does not contain: $pattern"
-    echo "    Actual line $n: $line"
+    echo "    Call $n in $path does not contain: $pattern"
+    echo "    Actual call $n: $block"
     return 1
   fi
 }
 
-assert_line_count() {
+assert_call_count() {
   local path="$1" expected="$2"
   local actual
-  actual="$(wc -l <"$path" 2>/dev/null | tr -d ' ')"
-  assert_eq "$expected" "$actual" "line count of $path"
+  actual="$(grep -c '^---END-CALL---$' "$path" 2>/dev/null || true)"
+  actual="${actual:-0}"
+  assert_eq "$expected" "$actual" "call count of $path"
 }
 
 run_test() {
@@ -296,7 +311,7 @@ test_is_error_gotcha_ignores_subtype_success() {
   assert_eq 1 "$rc" "exit code" &&
   assert_file_exists "$RUN_DIR/TRIPPED.md" &&
   assert_file_contains "$RUN_DIR/TRIPPED.md" "rail: error" &&
-  assert_line_count "$STUB_DIR/calls.log" 1
+  assert_call_count "$STUB_DIR/calls.log" 1
 }
 
 # ===========================================================================
@@ -335,8 +350,8 @@ $(baton_block CONTINUE step1 architect)" 0.01
 $(baton_block DONE step2)" 0.01
   run_trampollm --prompt "start" --agent dev
   assert_eq 0 "$rc" "exit code" &&
-  assert_line_contains "$STUB_DIR/calls.log" 1 "--agent dev" &&
-  assert_line_contains "$STUB_DIR/calls.log" 2 "--agent architect"
+  assert_call_contains "$STUB_DIR/calls.log" 1 "--agent dev" &&
+  assert_call_contains "$STUB_DIR/calls.log" 2 "--agent architect"
 }
 
 test_baton_audit_trail_verbatim() {
@@ -363,10 +378,10 @@ $(baton_block CONTINUE step1)" 0.01
 $(baton_block DONE step2)" 0.01
   run_trampollm --prompt "start" --max-turns 7 --max-budget-usd 0.5
   assert_eq 0 "$rc" "exit code" &&
-  assert_line_contains "$STUB_DIR/calls.log" 1 "--max-turns 7" &&
-  assert_line_contains "$STUB_DIR/calls.log" 1 "--max-budget-usd 0.5" &&
-  assert_line_contains "$STUB_DIR/calls.log" 2 "--max-turns 7" &&
-  assert_line_contains "$STUB_DIR/calls.log" 2 "--max-budget-usd 0.5"
+  assert_call_contains "$STUB_DIR/calls.log" 1 "--max-turns 7" &&
+  assert_call_contains "$STUB_DIR/calls.log" 1 "--max-budget-usd 0.5" &&
+  assert_call_contains "$STUB_DIR/calls.log" 2 "--max-turns 7" &&
+  assert_call_contains "$STUB_DIR/calls.log" 2 "--max-budget-usd 0.5"
 }
 
 # ===========================================================================
@@ -402,7 +417,7 @@ $(baton_block CONTINUE step3)" 0.015
   assert_eq 5 "$rc" "exit code" &&
   assert_file_exists "$RUN_DIR/TRIPPED.md" &&
   assert_file_contains "$RUN_DIR/TRIPPED.md" "rail: max-cost-usd" &&
-  assert_line_count "$STUB_DIR/calls.log" 2
+  assert_call_count "$STUB_DIR/calls.log" 2
 }
 
 test_identical_baton_loop_detection() {
@@ -418,7 +433,7 @@ $(baton_block CONTINUE same-step)" 0.01
 $(baton_block CONTINUE same-step)" 0.01
   run_trampollm --prompt "start"
   assert_eq 4 "$rc" "exit code" &&
-  assert_line_contains "$STUB_DIR/calls.log" 3 "Identical baton detected" &&
+  assert_call_contains "$STUB_DIR/calls.log" 3 "Identical baton detected" &&
   assert_file_exists "$RUN_DIR/TRIPPED.md" &&
   assert_file_contains "$RUN_DIR/TRIPPED.md" "rail: loop-detected"
 }
@@ -432,7 +447,7 @@ test_error_retry_with_backoff_then_success() {
 $(baton_block DONE recovered)" 0.01
   run_trampollm --prompt "start" --retries 3
   assert_eq 0 "$rc" "exit code" &&
-  assert_line_count "$STUB_DIR/calls.log" 3
+  assert_call_count "$STUB_DIR/calls.log" 3
 }
 
 test_error_retries_exhausted_trips() {
@@ -442,7 +457,7 @@ test_error_retries_exhausted_trips() {
   fixture_error 3 "transient error" 1 0
   run_trampollm --prompt "start" --retries 3
   assert_eq 1 "$rc" "exit code" &&
-  assert_line_count "$STUB_DIR/calls.log" 3 &&
+  assert_call_count "$STUB_DIR/calls.log" 3 &&
   assert_file_contains "$RUN_DIR/TRIPPED.md" "rail: error"
 }
 
@@ -452,7 +467,7 @@ test_malformed_baton_one_correction_then_trip() {
   fixture_ok 2 "still no baton block in this reply either." 0.01
   run_trampollm --prompt "start"
   assert_eq 1 "$rc" "exit code" &&
-  assert_line_contains "$STUB_DIR/calls.log" 2 "no valid BATON v1 block" &&
+  assert_call_contains "$STUB_DIR/calls.log" 2 "no valid BATON v1 block" &&
   assert_file_contains "$RUN_DIR/TRIPPED.md" "rail: malformed-baton"
 }
 
@@ -513,9 +528,12 @@ $(baton_block CONTINUE step1)" 0.01
 
 test_no_escalation_without_ticket() {
   setup_project
+  # baton_block's ticket arg is set empty here — otherwise the baton's own
+  # "ticket:" field would be picked up by the "baton can supply it" rule and
+  # this would no longer be testing the no-ticket path.
   fixture_ok 1 "bounce one.
 
-$(baton_block CONTINUE step1)" 0.01
+$(baton_block CONTINUE step1 '<same>' '')" 0.01
   run_trampollm --prompt "start" --max-bounces 1
   assert_eq 3 "$rc" "exit code" &&
   assert_file_not_exists "$STUB_DIR/gh.log"

--- a/scripts/tests/test-trampollm.sh
+++ b/scripts/tests/test-trampollm.sh
@@ -196,20 +196,19 @@ run_trampollm() {
   set -e
 }
 
-# run_trampollm_no_gh [args...] — like run_trampollm, but PATH contains ONLY
-# a bin/ dir with claude (no gh stub, no fallback to the real system PATH),
-# so `command -v gh` is guaranteed to fail deterministically and — even if
-# the guard were buggy — no real `gh` binary could ever be reached. Sets $rc.
+# run_trampollm_no_gh [args...] — like run_trampollm, but PATH is the stub
+# claude dir plus only bare-system dirs (/usr/bin, /bin, /usr/sbin, /sbin --
+# where `gh` is never installed; it lives under a package-manager prefix
+# like /opt/homebrew/bin or /usr/local/bin, both deliberately excluded).
+# No gh stub is created, so `command -v gh` is guaranteed to fail
+# deterministically, and even if the guard under test were buggy, no real
+# `gh` binary could ever be reached via this PATH. Sets $rc.
 run_trampollm_no_gh() {
   local nogh_bin="$PROJECT/nogh-bin"
   mkdir -p "$nogh_bin"
   cp "$PROJECT/bin/claude" "$nogh_bin/claude"
-  # jq is a real dependency (require_jq), so copy the real binary in --
-  # deliberately NOT adding its directory to PATH, since that directory
-  # may also contain a real `gh` (defeating the point of this harness).
-  cp -L "$(command -v jq)" "$nogh_bin/jq"
   set +e
-  PATH="$nogh_bin" TRAMPOLLM_BACKOFF_BASE=0 \
+  PATH="$nogh_bin:/usr/bin:/bin:/usr/sbin:/sbin" TRAMPOLLM_BACKOFF_BASE=0 \
     bash "$TRAMPOLLM" "$@" --run-id test-run >"$PROJECT/stdout.log" 2>"$PROJECT/stderr.log"
   rc=$?
   set -e

--- a/scripts/tests/test-trampollm.sh
+++ b/scripts/tests/test-trampollm.sh
@@ -19,6 +19,30 @@ PROJECT=""
 STUB_DIR=""
 rc=0
 
+# `timeout` is GNU coreutils: present on the CI runner (ubuntu-latest) and in
+# the pod container, absent from a stock macOS PATH. Resolving it up front
+# keeps the hang-guard tests from failing with 127 ("command not found") on a
+# maintainer's laptop and mis-reporting a portability gap as a script bug.
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="gtimeout"
+else
+  TIMEOUT_CMD=""
+  echo "NOTE: neither timeout(1) nor gtimeout found; hang-guard tests run unguarded" >&2
+fi
+
+# guarded <seconds> <cmd...> — run <cmd> under the timeout guard when one
+# exists, bare otherwise. Exit code 124 still means "timed out".
+guarded() {
+  local secs="$1"; shift
+  if [ -n "$TIMEOUT_CMD" ]; then
+    "$TIMEOUT_CMD" "$secs" "$@"
+  else
+    "$@"
+  fi
+}
+
 # --- Setup / teardown ---
 
 setup_project() {
@@ -323,7 +347,7 @@ test_arg_parser_valueless_trailing_flag_exits_1() {
   for flag in $VALUE_TAKING_FLAGS; do
     set +e
     PATH="$PROJECT/bin:$PATH" TRAMPOLLM_BACKOFF_BASE=0 \
-      timeout 5 bash "$TRAMPOLLM" "$flag" >"$PROJECT/stdout.log" 2>"$PROJECT/stderr.log"
+      guarded 5 bash "$TRAMPOLLM" "$flag" >"$PROJECT/stdout.log" 2>"$PROJECT/stderr.log"
     frc=$?
     set -e
     if [ "$frc" -eq 124 ]; then
@@ -358,7 +382,7 @@ test_arg_parser_rejects_non_numeric_rail_values() {
   for flag in --max-bounces --retries --max-cost-usd; do
     set +e
     PATH="$PROJECT/bin:$PATH" TRAMPOLLM_BACKOFF_BASE=0 \
-      timeout 5 bash "$TRAMPOLLM" --prompt "start" "$flag" abc --run-id "test-run-$flag" \
+      guarded 5 bash "$TRAMPOLLM" --prompt "start" "$flag" abc --run-id "test-run-$flag" \
       >"$PROJECT/stdout.log" 2>"$PROJECT/stderr.log"
     frc=$?
     set -e
@@ -738,6 +762,220 @@ $(baton_block CONTINUE step1)" 0.01
   assert_file_contains "$PROJECT/stderr.log" "gh not found; skipping escalation"
 }
 
+# ===========================================================================
+# Phase 6 — cost accounting, pre-flight, and corrective-prompt context
+# ===========================================================================
+
+# A dispatch that failed is still a billed dispatch. Summing only the winning
+# attempt let the cumulative rail under-count without bound.
+test_failed_attempts_count_toward_cumulative_cost() {
+  setup_project
+  fixture_error 1 "boom" 1 3.00
+  fixture_error 2 "boom" 1 3.00
+  fixture_ok 3 "recovered.
+
+$(baton_block DONE final)" 0.01
+  run_trampollm --prompt "start" --retries 3 --max-cost-usd 1.00
+  # One $3.00 failed attempt already blows the $1.00 cap, so the retry path
+  # stops there: 1 dispatch, not the 4 that --retries 3 would otherwise allow.
+  # Before the fix this run reached bounce 3 and exited 0 believing it had
+  # spent $0.01, because only the winning attempt was ever summed.
+  assert_eq 5 "$rc" "exit code (a \$3.00 failed attempt must trip a \$1.00 cap)" &&
+  assert_file_contains "$RUN_DIR/TRIPPED.md" "rail: max-cost-usd" &&
+  assert_file_contains "$RUN_DIR/TRIPPED.md" "cumulative_cost_usd: 3" &&
+  assert_call_count "$STUB_DIR/calls.log" 1
+}
+
+# The failed attempts' raw JSON/stderr must survive the retry that clobbers
+# the canonical NNN- paths -- otherwise the only evidence of what went wrong
+# is overwritten by the attempt that succeeded.
+test_failed_attempt_artifacts_preserved() {
+  setup_project
+  fixture_error 1 "first failure marker" 1 0
+  fixture_ok 2 "recovered.
+
+$(baton_block DONE final)" 0.01
+  run_trampollm --prompt "start" --retries 3
+  assert_eq 0 "$rc" "exit code" &&
+  assert_file_exists "$RUN_DIR/001-attempt1-response.json" &&
+  assert_file_contains "$RUN_DIR/001-attempt1-response.json" "first failure marker" &&
+  assert_file_exists "$RUN_DIR/001-response.json"
+}
+
+# Every bounce is a fresh context window, so a bare correction asks a model
+# that has never seen the task to "re-emit" something it knows nothing about.
+test_malformed_correction_carries_seed_context() {
+  setup_project
+  fixture_ok 1 "no baton block here." 0.01
+  fixture_ok 2 "recovered.
+
+$(baton_block DONE final)" 0.01
+  run_trampollm --prompt "SEED-TASK-MARKER: ship the widget parser"
+  assert_eq 0 "$rc" "exit code" &&
+  assert_call_contains "$STUB_DIR/calls.log" 2 "no valid BATON v1 block" &&
+  assert_call_contains "$STUB_DIR/calls.log" 2 "SEED-TASK-MARKER: ship the widget parser"
+}
+
+test_identical_correction_carries_baton_context() {
+  setup_project
+  fixture_ok 1 "one.
+
+$(baton_block CONTINUE same-step)" 0.01
+  fixture_ok 2 "two, identical.
+
+$(baton_block CONTINUE same-step)" 0.01
+  fixture_ok 3 "three, changed.
+
+$(baton_block DONE moved-on)" 0.01
+  run_trampollm --prompt "start"
+  assert_eq 0 "$rc" "exit code" &&
+  assert_call_contains "$STUB_DIR/calls.log" 3 "Identical baton detected" &&
+  assert_call_contains "$STUB_DIR/calls.log" 3 "next-step: same-step" &&
+  assert_call_contains "$STUB_DIR/calls.log" 3 "goal: relay test goal"
+}
+
+# Missing `claude` used to be indistinguishable from an API failure: the loop
+# burned RETRIES+1 dispatch attempts and wrote a TRIPPED.md whose only clue
+# was "rail: error".
+test_missing_claude_fails_fast_with_hint() {
+  setup_project
+  fixture_ok 1 "irrelevant" 0.01
+  set +e
+  PATH="/usr/bin:/bin:/usr/sbin:/sbin" TRAMPOLLM_BACKOFF_BASE=0 \
+    bash "$TRAMPOLLM" --prompt "start" --run-id test-run \
+    >"$PROJECT/stdout.log" 2>"$PROJECT/stderr.log"
+  rc=$?
+  set -e
+  assert_eq 1 "$rc" "exit code" &&
+  assert_file_contains "$PROJECT/stderr.log" "'claude' not found on PATH" &&
+  assert_file_not_exists "$RUN_DIR/TRIPPED.md"
+}
+
+# An unchecked mkdir meant every later redirect failed before claude was
+# execed, the loop read that as an API error, and TRIPPED.md could not be
+# written either. `memory` as a regular file makes mkdir fail even for root.
+test_unwritable_run_dir_fails_fast() {
+  setup_project
+  fixture_ok 1 "irrelevant" 0.01
+  printf 'not a directory\n' >"$PROJECT/memory"
+  set +e
+  PATH="$PROJECT/bin:$PATH" TRAMPOLLM_BACKOFF_BASE=0 \
+    guarded 10 bash "$TRAMPOLLM" --prompt "start" --run-id test-run \
+    >"$PROJECT/stdout.log" 2>"$PROJECT/stderr.log"
+  rc=$?
+  set -e
+  assert_eq 1 "$rc" "exit code" &&
+  assert_file_contains "$PROJECT/stderr.log" "cannot create run directory" &&
+  assert_eq "" "$(cat "$STUB_DIR/counter" 2>/dev/null || echo "")" "no dispatch may happen"
+}
+
+# A stale TRIPPED.md from an earlier run reusing this --run-id would outlive a
+# later clean run and make it look like it tripped.
+test_stale_tripped_md_cleared_on_rerun() {
+  setup_project
+  fixture_ok 1 "one.
+
+$(baton_block CONTINUE step1)" 0.01
+  run_trampollm --prompt "start" --max-bounces 1
+  assert_eq 3 "$rc" "first run trips" || return 1
+  assert_file_exists "$RUN_DIR/TRIPPED.md" || return 1
+  rm -f "$STUB_DIR/counter"
+  fixture_ok 1 "clean.
+
+$(baton_block DONE final)" 0.01
+  run_trampollm --prompt "start"
+  assert_eq 0 "$rc" "second run is clean" &&
+  assert_file_not_exists "$RUN_DIR/TRIPPED.md"
+}
+
+# Escalation IS the page to a human: a silent gh failure means nobody learns
+# the relay tripped.
+test_failed_gh_escalation_warns() {
+  setup_project
+  cat >"$PROJECT/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$STUB_DIR/gh.log"
+echo "gh: HTTP 401 Bad credentials" >&2
+exit 1
+STUB
+  chmod +x "$PROJECT/bin/gh"
+  fixture_ok 1 "one.
+
+$(baton_block CONTINUE step1)" 0.01
+  run_trampollm --prompt "start" --max-bounces 1 --ticket 108
+  assert_eq 3 "$rc" "trip exit code is unaffected by a failed page" &&
+  assert_file_exists "$RUN_DIR/TRIPPED.md" &&
+  assert_file_contains "$PROJECT/stderr.log" "nobody was paged" &&
+  assert_file_contains "$PROJECT/stderr.log" "--add-label needs-human' failed"
+}
+
+# ===========================================================================
+# Phase 7 — spec item 4: optional per-bounce issue comments
+# ===========================================================================
+
+test_comment_bounces_posts_each_baton() {
+  setup_project
+  fixture_ok 1 "one.
+
+$(baton_block CONTINUE step1)" 0.01
+  fixture_ok 2 "two, done.
+
+$(baton_block DONE step2)" 0.01
+  run_trampollm --prompt "start" --ticket 108 --comment-bounces
+  assert_eq 0 "$rc" "exit code" &&
+  assert_file_contains "$STUB_DIR/gh.log" "issue comment 108 --body-file" &&
+  assert_eq 2 "$(grep -c 'issue comment 108' "$STUB_DIR/gh.log")" "one comment per bounce"
+}
+
+test_comment_bounces_off_by_default() {
+  setup_project
+  fixture_ok 1 "one, done.
+
+$(baton_block DONE step1)" 0.01
+  run_trampollm --prompt "start" --ticket 108
+  assert_eq 0 "$rc" "exit code" &&
+  assert_file_not_exists "$STUB_DIR/gh.log"
+}
+
+# --comment-bounces is restricted to an operator-supplied ticket: a ticket
+# adopted out of a baton is model-authored, and one authenticated write per
+# bounce aimed at a model-chosen issue is not something to enable implicitly.
+test_comment_bounces_requires_cli_ticket() {
+  setup_project
+  fixture_ok 1 "irrelevant" 0.01
+  set +e
+  PATH="$PROJECT/bin:$PATH" TRAMPOLLM_BACKOFF_BASE=0 \
+    guarded 10 bash "$TRAMPOLLM" --prompt "start" --comment-bounces --run-id test-run \
+    >"$PROJECT/stdout.log" 2>"$PROJECT/stderr.log"
+  rc=$?
+  set -e
+  assert_eq 1 "$rc" "exit code" &&
+  assert_file_contains "$PROJECT/stderr.log" "--comment-bounces requires --ticket" &&
+  assert_eq "" "$(cat "$STUB_DIR/counter" 2>/dev/null || echo "")" "no dispatch may happen"
+}
+
+# ===========================================================================
+# Phase 8 — operator-facing progress
+# ===========================================================================
+
+# An unattended run that prints nothing at all while spending money is
+# unauditable until it is over. stdout stays clean; stderr carries progress.
+test_progress_logged_to_stderr_stdout_stays_clean() {
+  setup_project
+  fixture_ok 1 "one.
+
+$(baton_block CONTINUE step1)" 0.01
+  fixture_ok 2 "two, done.
+
+$(baton_block DONE step2)" 0.02
+  run_trampollm --prompt "start"
+  assert_eq 0 "$rc" "exit code" &&
+  assert_eq "" "$(cat "$PROJECT/stdout.log")" "stdout stays empty" &&
+  assert_file_contains "$PROJECT/stderr.log" "bounce 1: status=CONTINUE" &&
+  assert_file_contains "$PROJECT/stderr.log" "bounce 2: status=DONE" &&
+  assert_file_contains "$PROJECT/stderr.log" "cumulative cost"
+}
+
 # --- Run all tests ---
 
 echo "=== FEAT-018 trampollm Tests ==="
@@ -786,6 +1024,24 @@ run_test "TRIPPED.md contains rail/bounce/cost/last-baton" test_tripped_md_conte
 run_test "escalation posts gh comment + needs-human label when ticket set" test_escalation_with_ticket
 run_test "no gh calls when ticket unset" test_no_escalation_without_ticket
 run_test "escalation degrades gracefully (warns, no crash) when gh is absent" test_escalation_degrades_gracefully_without_gh
+echo ""
+echo "--- phase 6: cost accounting, pre-flight, corrective-prompt context ---"
+run_test "failed dispatch attempts count toward the cumulative cost rail" test_failed_attempts_count_toward_cumulative_cost
+run_test "failed attempts' response/stderr artifacts survive the retry" test_failed_attempt_artifacts_preserved
+run_test "malformed correction re-sends the seed, not a context-free scolding" test_malformed_correction_carries_seed_context
+run_test "identical correction re-sends the repeated baton with the scolding" test_identical_correction_carries_baton_context
+run_test "missing 'claude' fails fast with a hint, no dispatch attempts" test_missing_claude_fails_fast_with_hint
+run_test "uncreatable run dir fails fast before any dispatch" test_unwritable_run_dir_fails_fast
+run_test "stale TRIPPED.md removed when a run-id is reused" test_stale_tripped_md_cleared_on_rerun
+run_test "failed gh escalation warns loudly, trip exit code unchanged" test_failed_gh_escalation_warns
+echo ""
+echo "--- phase 7: optional per-bounce issue comments (spec item 4) ---"
+run_test "--comment-bounces posts each baton via --body-file" test_comment_bounces_posts_each_baton
+run_test "per-bounce comments are off by default" test_comment_bounces_off_by_default
+run_test "--comment-bounces requires an operator-supplied --ticket" test_comment_bounces_requires_cli_ticket
+echo ""
+echo "--- phase 8: operator-facing progress ---"
+run_test "progress on stderr, stdout stays clean" test_progress_logged_to_stderr_stdout_stays_clean
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/tests/test-trampollm.sh
+++ b/scripts/tests/test-trampollm.sh
@@ -1,0 +1,564 @@
+#!/usr/bin/env bash
+# FEAT-018: Tests for scripts/trampollm.sh (the continuation trampoline).
+# Run from repo root: bash scripts/tests/test-trampollm.sh
+#
+# Zero API spend: `claude` and `gh` are PATH shims (canned JSON fixtures /
+# call loggers). The real CLIs are never invoked.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+TMPDIR_BASE=""
+
+# Capture REPO_ROOT before any cd operations
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TRAMPOLLM="$REPO_ROOT/scripts/trampollm.sh"
+
+PROJECT=""
+STUB_DIR=""
+rc=0
+
+# --- Setup / teardown ---
+
+setup_project() {
+  TMPDIR_BASE=$(mktemp -d)
+  PROJECT="$TMPDIR_BASE/project"
+  mkdir -p "$PROJECT/bin" "$PROJECT/fixtures"
+  cd "$PROJECT"
+  STUB_DIR="$PROJECT/fixtures"
+  export STUB_DIR
+
+  cat >bin/claude <<'STUB'
+#!/usr/bin/env bash
+# stub claude — emits canned JSON per invocation, logs args, zero API spend.
+n=$(cat "$STUB_DIR/counter" 2>/dev/null || echo 0); n=$((n+1))
+printf '%s\n' "$n" > "$STUB_DIR/counter"
+printf '%s\n' "$*" >> "$STUB_DIR/calls.log"
+cat "$STUB_DIR/response_${n}.json" 2>/dev/null
+exit "$(cat "$STUB_DIR/response_${n}.exit" 2>/dev/null || echo 0)"
+STUB
+  chmod +x bin/claude
+
+  cat >bin/gh <<'STUB'
+#!/usr/bin/env bash
+# stub gh — records comment/label calls, zero network.
+printf '%s\n' "$*" >> "$STUB_DIR/gh.log"
+exit 0
+STUB
+  chmod +x bin/gh
+}
+
+teardown() {
+  if [ -n "$TMPDIR_BASE" ] && [ -d "$TMPDIR_BASE" ]; then
+    rm -rf "$TMPDIR_BASE"
+  fi
+}
+trap teardown EXIT
+
+# --- Fixture builders ---
+
+# baton_block <status> <next_step> [next_agent] [ticket] [breadcrumbs]
+baton_block() {
+  local status="$1" next_step="$2" next_agent="${3:-<same>}" ticket="${4:-#108}" breadcrumbs="${5:-none}"
+  printf -- '--- BATON v1 ---\nstatus: %s\ngoal: relay test goal\nticket: %s\nnext-agent: %s\ndone-criteria: counter reaches threshold\nstate: in progress\nnext-step: %s\nbreadcrumbs: %s\n--- END BATON ---' \
+    "$status" "$ticket" "$next_agent" "$next_step" "$breadcrumbs"
+}
+
+# fixture_ok <n> <result_text> [cost]
+fixture_ok() {
+  local n="$1" result_text="$2" cost="${3:-0.01}"
+  jq -n --arg result "$result_text" --argjson cost "$cost" \
+    '{result: $result, session_id: "sess-test", total_cost_usd: $cost, is_error: false, subtype: "success", terminal_reason: "stop", num_turns: 3}' \
+    >"$STUB_DIR/response_${n}.json"
+}
+
+# fixture_error <n> [result_text] [exit_code] [cost]
+fixture_error() {
+  local n="$1" result_text="${2:-API error: bogus model}" exit_code="${3:-1}" cost="${4:-0}"
+  jq -n --arg result "$result_text" --argjson cost "$cost" \
+    '{result: $result, session_id: "sess-test", total_cost_usd: $cost, is_error: true, subtype: "success", terminal_reason: "api_error", num_turns: 1}' \
+    >"$STUB_DIR/response_${n}.json"
+  printf '%s\n' "$exit_code" >"$STUB_DIR/response_${n}.exit"
+}
+
+# --- Assertions ---
+
+assert_eq() {
+  local expected="$1" actual="$2" label="${3:-value}"
+  if [ "$expected" = "$actual" ]; then
+    return 0
+  else
+    echo "    $label: expected [$expected], got [$actual]"
+    return 1
+  fi
+}
+
+assert_file_exists() {
+  local path="$1"
+  if [ -f "$path" ]; then
+    return 0
+  else
+    echo "    File does not exist: $path"
+    return 1
+  fi
+}
+
+assert_file_not_exists() {
+  local path="$1"
+  if [ -f "$path" ]; then
+    echo "    File should NOT exist: $path"
+    return 1
+  fi
+  return 0
+}
+
+assert_file_contains() {
+  local path="$1" pattern="$2"
+  if grep -qF "$pattern" "$path" 2>/dev/null; then
+    return 0
+  else
+    echo "    File $path does not contain: $pattern"
+    return 1
+  fi
+}
+
+assert_line_contains() {
+  local path="$1" n="$2" pattern="$3"
+  local line
+  line="$(sed -n "${n}p" "$path" 2>/dev/null || true)"
+  if printf '%s' "$line" | grep -qF "$pattern"; then
+    return 0
+  else
+    echo "    Line $n of $path does not contain: $pattern"
+    echo "    Actual line $n: $line"
+    return 1
+  fi
+}
+
+assert_line_count() {
+  local path="$1" expected="$2"
+  local actual
+  actual="$(wc -l <"$path" 2>/dev/null | tr -d ' ')"
+  assert_eq "$expected" "$actual" "line count of $path"
+}
+
+run_test() {
+  local name="$1"
+  shift
+  if "$@" 2>&1; then
+    echo "  PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# call_fn <fn> [args...] — run a pure helper from trampollm.sh in an
+# isolated subshell (source-guard prevents main() from firing).
+call_fn() {
+  ( source "$TRAMPOLLM"; "$@" )
+}
+
+# run_trampollm [args...] — invoke trampollm.sh against the current
+# PROJECT's stubs, deterministic run-id, zero backoff. Sets $rc.
+run_trampollm() {
+  set +e
+  PATH="$PROJECT/bin:$PATH" TRAMPOLLM_BACKOFF_BASE=0 \
+    bash "$TRAMPOLLM" "$@" --run-id test-run >"$PROJECT/stdout.log" 2>"$PROJECT/stderr.log"
+  rc=$?
+  set -e
+}
+
+RUN_DIR="memory/trampoline/test-run"
+
+# ===========================================================================
+# Phase 1 — helpers & guards
+# ===========================================================================
+
+test_require_jq_fails_without_jq() {
+  local out fnrc
+  set +e
+  out=$(
+    (
+      PATH="/nonexistent-only-dir-$$"
+      source "$TRAMPOLLM"
+      require_jq
+    ) 2>&1
+  )
+  fnrc=$?
+  set -e
+  [ "$fnrc" -eq 1 ] || { echo "    expected rc=1, got $fnrc"; return 1; }
+  echo "$out" | grep -qi "jq is required" || { echo "    missing 'jq is required' hint: $out"; return 1; }
+  echo "$out" | grep -qi "install" || { echo "    missing install hint: $out"; return 1; }
+}
+
+test_parse_baton_extracts_from_prose() {
+  local text block
+  text="Some prose before.
+
+$(baton_block CONTINUE step1)
+
+Some prose after."
+  block="$(call_fn parse_baton "$text")"
+  printf '%s' "$block" | grep -qF -- '--- BATON v1 ---' || { echo "    missing start fence: $block"; return 1; }
+  printf '%s' "$block" | grep -qF -- '--- END BATON ---' || { echo "    missing end fence: $block"; return 1; }
+  printf '%s' "$block" | grep -qF 'status: CONTINUE' || { echo "    missing status line: $block"; return 1; }
+}
+
+test_parse_baton_empty_when_no_fence() {
+  local block
+  block="$(call_fn parse_baton "just plain prose, no baton block here at all")"
+  assert_eq "" "$block" "parse_baton with no fence"
+}
+
+test_parse_baton_returns_last_block() {
+  local text block
+  text="$(baton_block CONTINUE first-step)
+
+some interstitial prose
+
+$(baton_block CONTINUE second-step)"
+  block="$(call_fn parse_baton "$text")"
+  printf '%s' "$block" | grep -qF 'next-step: second-step' || { echo "    expected last block (second-step): $block"; return 1; }
+  if printf '%s' "$block" | grep -qF 'next-step: first-step'; then
+    echo "    block unexpectedly contains the first block's next-step: $block"
+    return 1
+  fi
+}
+
+test_baton_field_whitespace_tolerant() {
+  local block status next_agent ticket
+  block="$(printf -- '--- BATON v1 ---\nstatus:   continue  \ngoal: g\nticket:  #108 \nnext-agent:  architect \ndone-criteria: c\nstate: s\nnext-step: n\nbreadcrumbs: none\n--- END BATON ---')"
+  status="$(call_fn baton_status "$block")"
+  next_agent="$(call_fn baton_field "$block" "next-agent")"
+  ticket="$(call_fn baton_field "$block" "ticket")"
+  assert_eq "CONTINUE" "$status" "baton_status" &&
+  assert_eq "architect" "$next_agent" "next-agent field" &&
+  assert_eq "#108" "$ticket" "ticket field"
+}
+
+test_normalize_hash_stable_across_breadcrumbs() {
+  local block_a block_b hash_a hash_b
+  block_a="$(baton_block CONTINUE step1 architect '#108' 'none')"
+  block_b="$(baton_block CONTINUE step1 architect '#108' 'tried X, failed with Y')"
+  hash_a="$(call_fn hash_baton "$block_a")"
+  hash_b="$(call_fn hash_baton "$block_b")"
+  assert_eq "$hash_a" "$hash_b" "hash stable across breadcrumbs-only diff"
+}
+
+test_hash_differs_on_next_step_change() {
+  local block_a block_c hash_a hash_c
+  block_a="$(baton_block CONTINUE step1 architect '#108' 'none')"
+  block_c="$(baton_block CONTINUE step2 architect '#108' 'none')"
+  hash_a="$(call_fn hash_baton "$block_a")"
+  hash_c="$(call_fn hash_baton "$block_c")"
+  if [ "$hash_a" = "$hash_c" ]; then
+    echo "    hash should differ when next-step changes"
+    return 1
+  fi
+  return 0
+}
+
+# ===========================================================================
+# Phase 2 — single bounce & the is_error gotcha
+# ===========================================================================
+
+test_clean_single_bounce_done() {
+  setup_project
+  fixture_ok 1 "work done.
+
+$(baton_block DONE final)" 0.01
+  run_trampollm --prompt "do the thing"
+  assert_eq 0 "$rc" "exit code" &&
+  assert_file_exists "$RUN_DIR/001-baton.md" &&
+  assert_file_contains "$RUN_DIR/001-baton.md" "status: DONE"
+}
+
+test_is_error_gates_before_result() {
+  setup_project
+  fixture_error 1 "malicious prose that must never be dispatched" 1 0
+  fixture_error 2 "malicious prose that must never be dispatched" 1 0
+  fixture_error 3 "malicious prose that must never be dispatched" 1 0
+  run_trampollm --prompt "do the thing"
+  assert_eq 1 "$rc" "exit code" &&
+  assert_file_exists "$RUN_DIR/TRIPPED.md" &&
+  assert_file_contains "$RUN_DIR/TRIPPED.md" "rail: error" &&
+  assert_file_not_exists "$RUN_DIR/001-baton.md"
+}
+
+test_is_error_gotcha_ignores_subtype_success() {
+  setup_project
+  # exit 1, is_error:true, but subtype stays "success" — the FEAT-017 gotcha.
+  fixture_error 1 "misleading prose" 1 0
+  run_trampollm --prompt "do the thing" --retries 1
+  assert_eq 1 "$rc" "exit code" &&
+  assert_file_exists "$RUN_DIR/TRIPPED.md" &&
+  assert_file_contains "$RUN_DIR/TRIPPED.md" "rail: error" &&
+  assert_line_count "$STUB_DIR/calls.log" 1
+}
+
+# ===========================================================================
+# Phase 3 — multi-bounce loop
+# ===========================================================================
+
+test_sentinel_termination_three_continue_then_done() {
+  setup_project
+  fixture_ok 1 "step one.
+
+$(baton_block CONTINUE step1)" 0.01
+  fixture_ok 2 "step two.
+
+$(baton_block CONTINUE step2)" 0.01
+  fixture_ok 3 "step three.
+
+$(baton_block CONTINUE step3)" 0.01
+  fixture_ok 4 "step four, done.
+
+$(baton_block DONE step4)" 0.01
+  run_trampollm --prompt "start the relay"
+  assert_eq 0 "$rc" "exit code" &&
+  assert_file_exists "$RUN_DIR/001-baton.md" &&
+  assert_file_exists "$RUN_DIR/002-baton.md" &&
+  assert_file_exists "$RUN_DIR/003-baton.md" &&
+  assert_file_exists "$RUN_DIR/004-baton.md"
+}
+
+test_next_agent_routing() {
+  setup_project
+  fixture_ok 1 "bounce one.
+
+$(baton_block CONTINUE step1 architect)" 0.01
+  fixture_ok 2 "bounce two, done.
+
+$(baton_block DONE step2)" 0.01
+  run_trampollm --prompt "start" --agent dev
+  assert_eq 0 "$rc" "exit code" &&
+  assert_line_contains "$STUB_DIR/calls.log" 1 "--agent dev" &&
+  assert_line_contains "$STUB_DIR/calls.log" 2 "--agent architect"
+}
+
+test_baton_audit_trail_verbatim() {
+  setup_project
+  fixture_ok 1 "bounce one.
+
+$(baton_block CONTINUE unique-marker-abc)" 0.01
+  fixture_ok 2 "bounce two, done.
+
+$(baton_block DONE unique-marker-xyz)" 0.01
+  run_trampollm --prompt "start"
+  assert_eq 0 "$rc" "exit code" &&
+  assert_file_contains "$RUN_DIR/001-baton.md" "unique-marker-abc" &&
+  assert_file_contains "$RUN_DIR/002-baton.md" "unique-marker-xyz"
+}
+
+test_pass_through_flags_every_call() {
+  setup_project
+  fixture_ok 1 "bounce one.
+
+$(baton_block CONTINUE step1)" 0.01
+  fixture_ok 2 "bounce two, done.
+
+$(baton_block DONE step2)" 0.01
+  run_trampollm --prompt "start" --max-turns 7 --max-budget-usd 0.5
+  assert_eq 0 "$rc" "exit code" &&
+  assert_line_contains "$STUB_DIR/calls.log" 1 "--max-turns 7" &&
+  assert_line_contains "$STUB_DIR/calls.log" 1 "--max-budget-usd 0.5" &&
+  assert_line_contains "$STUB_DIR/calls.log" 2 "--max-turns 7" &&
+  assert_line_contains "$STUB_DIR/calls.log" 2 "--max-budget-usd 0.5"
+}
+
+# ===========================================================================
+# Phase 4 — rails
+# ===========================================================================
+
+test_max_bounces_trip() {
+  setup_project
+  fixture_ok 1 "bounce one.
+
+$(baton_block CONTINUE step1)" 0.01
+  fixture_ok 2 "bounce two.
+
+$(baton_block CONTINUE step2)" 0.01
+  run_trampollm --prompt "start" --max-bounces 2
+  assert_eq 3 "$rc" "exit code" &&
+  assert_file_exists "$RUN_DIR/TRIPPED.md" &&
+  assert_file_contains "$RUN_DIR/TRIPPED.md" "rail: max-bounces"
+}
+
+test_cumulative_cost_trip_before_dispatch() {
+  setup_project
+  fixture_ok 1 "bounce one.
+
+$(baton_block CONTINUE step1)" 0.015
+  fixture_ok 2 "bounce two.
+
+$(baton_block CONTINUE step2)" 0.015
+  fixture_ok 3 "bounce three -- should never be dispatched.
+
+$(baton_block CONTINUE step3)" 0.015
+  run_trampollm --prompt "start" --max-cost-usd 0.02
+  assert_eq 5 "$rc" "exit code" &&
+  assert_file_exists "$RUN_DIR/TRIPPED.md" &&
+  assert_file_contains "$RUN_DIR/TRIPPED.md" "rail: max-cost-usd" &&
+  assert_line_count "$STUB_DIR/calls.log" 2
+}
+
+test_identical_baton_loop_detection() {
+  setup_project
+  fixture_ok 1 "bounce one.
+
+$(baton_block CONTINUE same-step)" 0.01
+  fixture_ok 2 "bounce two, identical.
+
+$(baton_block CONTINUE same-step)" 0.01
+  fixture_ok 3 "bounce three, identical again.
+
+$(baton_block CONTINUE same-step)" 0.01
+  run_trampollm --prompt "start"
+  assert_eq 4 "$rc" "exit code" &&
+  assert_line_contains "$STUB_DIR/calls.log" 3 "Identical baton detected" &&
+  assert_file_exists "$RUN_DIR/TRIPPED.md" &&
+  assert_file_contains "$RUN_DIR/TRIPPED.md" "rail: loop-detected"
+}
+
+test_error_retry_with_backoff_then_success() {
+  setup_project
+  fixture_error 1 "transient error" 1 0
+  fixture_error 2 "transient error" 1 0
+  fixture_ok 3 "recovered, done.
+
+$(baton_block DONE recovered)" 0.01
+  run_trampollm --prompt "start" --retries 3
+  assert_eq 0 "$rc" "exit code" &&
+  assert_line_count "$STUB_DIR/calls.log" 3
+}
+
+test_error_retries_exhausted_trips() {
+  setup_project
+  fixture_error 1 "transient error" 1 0
+  fixture_error 2 "transient error" 1 0
+  fixture_error 3 "transient error" 1 0
+  run_trampollm --prompt "start" --retries 3
+  assert_eq 1 "$rc" "exit code" &&
+  assert_line_count "$STUB_DIR/calls.log" 3 &&
+  assert_file_contains "$RUN_DIR/TRIPPED.md" "rail: error"
+}
+
+test_malformed_baton_one_correction_then_trip() {
+  setup_project
+  fixture_ok 1 "no baton block in this reply at all." 0.01
+  fixture_ok 2 "still no baton block in this reply either." 0.01
+  run_trampollm --prompt "start"
+  assert_eq 1 "$rc" "exit code" &&
+  assert_line_contains "$STUB_DIR/calls.log" 2 "no valid BATON v1 block" &&
+  assert_file_contains "$RUN_DIR/TRIPPED.md" "rail: malformed-baton"
+}
+
+test_status_park_trips() {
+  setup_project
+  fixture_ok 1 "parking.
+
+$(baton_block PARK blocked-on-human)" 0.01
+  run_trampollm --prompt "start"
+  assert_eq 2 "$rc" "exit code" &&
+  assert_file_exists "$RUN_DIR/TRIPPED.md" &&
+  assert_file_contains "$RUN_DIR/TRIPPED.md" "rail: park"
+}
+
+test_status_escalate_trips() {
+  setup_project
+  fixture_ok 1 "escalating.
+
+$(baton_block ESCALATE needs-human-call)" 0.01
+  run_trampollm --prompt "start"
+  assert_eq 2 "$rc" "exit code" &&
+  assert_file_exists "$RUN_DIR/TRIPPED.md" &&
+  assert_file_contains "$RUN_DIR/TRIPPED.md" "rail: escalate"
+}
+
+# ===========================================================================
+# Phase 5 — trip observability & escalation
+# ===========================================================================
+
+test_tripped_md_content() {
+  setup_project
+  fixture_ok 1 "bounce one.
+
+$(baton_block CONTINUE marker-content-check)" 0.01
+  fixture_ok 2 "bounce two.
+
+$(baton_block CONTINUE step2)" 0.01
+  run_trampollm --prompt "start" --max-bounces 2
+  assert_eq 3 "$rc" "exit code" &&
+  assert_file_contains "$RUN_DIR/TRIPPED.md" "rail: max-bounces" &&
+  assert_file_contains "$RUN_DIR/TRIPPED.md" "bounce: 2" &&
+  assert_file_contains "$RUN_DIR/TRIPPED.md" "cumulative_cost_usd:" &&
+  assert_file_contains "$RUN_DIR/TRIPPED.md" "--- BATON v1 ---" &&
+  assert_file_contains "$RUN_DIR/TRIPPED.md" "step2"
+}
+
+test_escalation_with_ticket() {
+  setup_project
+  fixture_ok 1 "bounce one.
+
+$(baton_block CONTINUE step1)" 0.01
+  run_trampollm --prompt "start" --max-bounces 1 --ticket 108
+  assert_eq 3 "$rc" "exit code" &&
+  assert_file_exists "$STUB_DIR/gh.log" &&
+  assert_file_contains "$STUB_DIR/gh.log" "issue comment 108" &&
+  assert_file_contains "$STUB_DIR/gh.log" "issue edit 108 --add-label needs-human"
+}
+
+test_no_escalation_without_ticket() {
+  setup_project
+  fixture_ok 1 "bounce one.
+
+$(baton_block CONTINUE step1)" 0.01
+  run_trampollm --prompt "start" --max-bounces 1
+  assert_eq 3 "$rc" "exit code" &&
+  assert_file_not_exists "$STUB_DIR/gh.log"
+}
+
+# --- Run all tests ---
+
+echo "=== FEAT-018 trampollm Tests ==="
+echo ""
+echo "--- phase 1: helpers & guards ---"
+run_test "require_jq fails with install hint when jq absent" test_require_jq_fails_without_jq
+run_test "parse_baton extracts block from surrounding prose" test_parse_baton_extracts_from_prose
+run_test "parse_baton returns empty when no fence" test_parse_baton_empty_when_no_fence
+run_test "parse_baton returns the last block when two present" test_parse_baton_returns_last_block
+run_test "baton_field/baton_status whitespace-tolerant" test_baton_field_whitespace_tolerant
+run_test "hash_baton stable across breadcrumbs-only diff" test_normalize_hash_stable_across_breadcrumbs
+run_test "hash_baton differs on next-step change" test_hash_differs_on_next_step_change
+echo ""
+echo "--- phase 2: single bounce & is_error gotcha ---"
+run_test "clean single bounce DONE -> exit 0, writes 001-baton.md" test_clean_single_bounce_done
+run_test "is_error gates before .result is dispatched" test_is_error_gates_before_result
+run_test "gotcha: is_error true + subtype success still trips as error" test_is_error_gotcha_ignores_subtype_success
+echo ""
+echo "--- phase 3: multi-bounce loop ---"
+run_test "sentinel termination: 3 CONTINUE then DONE -> exit 0" test_sentinel_termination_three_continue_then_done
+run_test "next-agent routing switches --agent on later bounces" test_next_agent_routing
+run_test "baton audit trail written verbatim per bounce" test_baton_audit_trail_verbatim
+run_test "pass-through flags appear on every call" test_pass_through_flags_every_call
+echo ""
+echo "--- phase 4: rails ---"
+run_test "--max-bounces trip -> exit 3" test_max_bounces_trip
+run_test "cumulative cost trip checked before dispatch -> exit 5" test_cumulative_cost_trip_before_dispatch
+run_test "identical-baton loop detection -> exit 4" test_identical_baton_loop_detection
+run_test "error retry with backoff then success -> exit 0" test_error_retry_with_backoff_then_success
+run_test "error retries exhausted -> exit 1" test_error_retries_exhausted_trips
+run_test "malformed baton: one correction then trip -> exit 1" test_malformed_baton_one_correction_then_trip
+run_test "status PARK trips -> exit 2" test_status_park_trips
+run_test "status ESCALATE trips -> exit 2" test_status_escalate_trips
+echo ""
+echo "--- phase 5: trip observability & escalation ---"
+run_test "TRIPPED.md contains rail/bounce/cost/last-baton" test_tripped_md_content
+run_test "escalation posts gh comment + needs-human label when ticket set" test_escalation_with_ticket
+run_test "no gh calls when ticket unset" test_no_escalation_without_ticket
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/trampollm.sh
+++ b/scripts/trampollm.sh
@@ -57,6 +57,27 @@ require_jq() {
   return 0
 }
 
+# require_claude — the whole point of the script is dispatching `claude`.
+# Without this pre-flight, a missing/not-on-PATH CLI is indistinguishable
+# from an API failure: run_claude's redirect still succeeds, bash reports
+# "claude: command not found" into the per-bounce stderr log, and the loop
+# burns RETRIES+1 dispatch attempts with backoff before writing a TRIPPED.md
+# whose only clue is "rail: error" and an empty last-baton section.
+require_claude() {
+  if ! command -v claude >/dev/null 2>&1; then
+    echo "trampollm: 'claude' not found on PATH (Claude Code CLI is required)" >&2
+    return 1
+  fi
+  return 0
+}
+
+# log <msg> — operator-facing progress on stderr. stdout stays clean so the
+# script composes into pipelines; an unattended run that prints nothing at
+# all (the prior behaviour) is unauditable while it is still running.
+log() {
+  echo "trampollm: $*" >&2
+}
+
 # parse_baton <text> — prints the block between "--- BATON v1 ---" and
 # "--- END BATON ---" (inclusive). Prints empty string if absent. If the
 # text contains multiple blocks, the LAST one wins.
@@ -171,15 +192,24 @@ is_bad_response() {
 }
 
 # write_baton_file <run_dir> <n> <block> — writes <run_dir>/NNN-baton.md verbatim.
+# A failed write (full disk, read-only mount) is announced rather than
+# swallowed: the baton chain IS the audit trail, so losing a link silently
+# is worse than the run failing loudly.
 write_baton_file() {
   local run_dir="$1" n="$2" block="$3"
-  printf '%s\n' "$block" >"$run_dir/$(printf '%03d' "$n")-baton.md"
+  local path
+  path="$run_dir/$(printf '%03d' "$n")-baton.md"
+  if ! printf '%s\n' "$block" >"$path" 2>/dev/null; then
+    log "WARNING: could not write $path (disk full / read-only?)"
+    return 1
+  fi
+  return 0
 }
 
 # write_tripped <run_dir> <rail> <bounce> <cum_cost> <last_baton>
 write_tripped() {
   local run_dir="$1" rail="$2" bounce="$3" cum_cost="$4" last_baton="$5"
-  {
+  if ! {
     echo "trampollm: TRIPPED"
     echo ""
     echo "rail: $rail"
@@ -188,7 +218,11 @@ write_tripped() {
     echo ""
     echo "--- last good baton (resume by feeding this back in) ---"
     printf '%s\n' "$last_baton"
-  } >"$run_dir/TRIPPED.md"
+  } >"$run_dir/TRIPPED.md" 2>/dev/null; then
+    log "WARNING: could not write $run_dir/TRIPPED.md (disk full / read-only?)"
+    return 1
+  fi
+  return 0
 }
 
 # escalate_ticket <ticket> <tripped_path> — when <ticket> is non-empty, posts
@@ -203,8 +237,63 @@ escalate_ticket() {
     return 0
   fi
   local num="${ticket#\#}"
-  gh issue comment "$num" --body-file "$tripped_path" >/dev/null
-  gh issue edit "$num" --add-label needs-human >/dev/null
+  # Both gh calls' exit codes are checked: escalation IS the page to a human,
+  # so a silent failure (expired auth, rate limit, no `needs-human` label in
+  # the repo, network down) means nobody ever learns the relay tripped. The
+  # trip's own exit code is unaffected -- a failed page must not mask the
+  # rail that fired -- but it is now visible on stderr.
+  if ! gh issue comment "$num" --body-file "$tripped_path" >/dev/null; then
+    log "WARNING: 'gh issue comment $num' failed; nobody was paged. Trip details: $tripped_path"
+  fi
+  if ! gh issue edit "$num" --add-label needs-human >/dev/null; then
+    log "WARNING: 'gh issue edit $num --add-label needs-human' failed (label missing in repo?)"
+  fi
+}
+
+# comment_bounce <ticket> <baton_path> <bounce> — spec item 4's optional
+# per-bounce issue comment, via the same --body-file pattern as escalation.
+# Opt-in through --comment-bounces, and deliberately restricted to a ticket
+# the OPERATOR passed on the CLI (see main()): a ticket adopted out of a
+# baton is model-authored, and one authenticated write per bounce aimed at
+# a model-chosen issue is not something to turn on by default.
+comment_bounce() {
+  local ticket="$1" baton_path="$2" bounce="$3"
+  if [ -z "$ticket" ]; then
+    log "WARNING: --comment-bounces needs --ticket; skipping comment for bounce $bounce"
+    return 0
+  fi
+  if ! command -v gh >/dev/null 2>&1; then
+    log "WARNING: gh not found; skipping per-bounce comment for bounce $bounce"
+    return 0
+  fi
+  if [ ! -f "$baton_path" ]; then
+    return 0
+  fi
+  local num="${ticket#\#}"
+  if ! gh issue comment "$num" --body-file "$baton_path" >/dev/null; then
+    log "WARNING: per-bounce 'gh issue comment $num' failed for bounce $bounce"
+  fi
+}
+
+# accumulate_cost <out_json> — adds this dispatch's .total_cost_usd into the
+# enclosing main()'s cum_cost (dynamic scope, same convention as run_claude).
+#
+# Called for EVERY dispatch, including ones that failed is_bad_response. A
+# bounce that errors after doing work is still a billed run, so summing only
+# the winning attempt let the cumulative rail under-count without bound:
+# observed, two failed attempts billing $3.00 each vanished entirely under a
+# --max-cost-usd 1.00 cap and the run exited 0 believing it had spent $0.01.
+accumulate_cost() {
+  local out_json="$1" c
+  [ -s "$out_json" ] || return 0
+  # Guard the type: a non-numeric or absent total_cost_usd must contribute 0
+  # rather than poison cum_cost into a string and make the awk rail inert.
+  c="$(jq -r 'if (.total_cost_usd | type) == "number" then .total_cost_usd else 0 end' "$out_json" 2>/dev/null)"
+  case "${c:-}" in
+    ''|*[!0-9.eE+-]*) return 0 ;;
+  esac
+  cum_cost="$(awk -v a="$cum_cost" -v b="$c" 'BEGIN { printf "%s", a + b }')"
+  return 0
 }
 
 # backoff_sleep <attempt> — sleep(TRAMPOLLM_BACKOFF_BASE * attempt).
@@ -233,11 +322,14 @@ Options:
   --retries <N>             Retries after the initial attempt (default: 3)
                             -- N+1 total dispatches per bounce on failure
   --ticket <#NNN>           Seeds ticket; trips post a comment + needs-human label
+  --comment-bounces         Also post each bounce's baton as an issue comment
+                            (takes no value; requires --ticket)
   --run-id <id>             Overridable run id (default: timestamp-pid)
   --model <model>           Native pass-through when set
 
-Every option above requires a value; a trailing flag with no value
-(e.g. "trampollm.sh --prompt") is a usage error -> exit 1.
+Every option above except --comment-bounces, -h and --help requires a value;
+a trailing value-taking flag with no value (e.g. "trampollm.sh --prompt") is
+a usage error -> exit 1.
 EOF
 }
 
@@ -292,6 +384,7 @@ validate_nonneg_number() {
 
 main() {
   require_jq || exit 1
+  require_claude || exit 1
 
   local PROMPT=""
   AGENT="$DEFAULT_AGENT"
@@ -301,6 +394,10 @@ main() {
   local MAX_COST_USD="$DEFAULT_MAX_COST_USD"
   local RETRIES="$DEFAULT_RETRIES"
   local TICKET=""
+  # CLI_TICKET is TICKET's operator-supplied subset. TICKET may later be
+  # adopted from a baton (model-authored); CLI_TICKET never is.
+  local CLI_TICKET=""
+  local COMMENT_BOUNCES=false
   local RUN_ID
   RUN_ID="$(date +%Y%m%dT%H%M%S)-$$"
   MODEL=""
@@ -314,7 +411,8 @@ main() {
       --max-budget-usd) require_flag_value "$1" "$#"; validate_nonneg_number "$1" "$2"; MAX_BUDGET_USD="$2"; shift 2 ;;
       --max-cost-usd) require_flag_value "$1" "$#"; validate_nonneg_number "$1" "$2"; MAX_COST_USD="$2"; shift 2 ;;
       --retries) require_flag_value "$1" "$#"; validate_nonneg_int "$1" "$2"; RETRIES="$2"; shift 2 ;;
-      --ticket) require_flag_value "$1" "$#"; TICKET="$2"; shift 2 ;;
+      --ticket) require_flag_value "$1" "$#"; TICKET="$2"; CLI_TICKET="$2"; shift 2 ;;
+      --comment-bounces) COMMENT_BOUNCES=true; shift ;;
       --run-id) require_flag_value "$1" "$#"; RUN_ID="$2"; shift 2 ;;
       --model) require_flag_value "$1" "$#"; MODEL="$2"; shift 2 ;;
       -h|--help) usage; exit 0 ;;
@@ -328,11 +426,36 @@ main() {
     exit 1
   fi
 
-  local run_dir="memory/trampoline/${RUN_ID}"
-  mkdir -p "$run_dir"
+  if [ "$COMMENT_BOUNCES" = true ] && [ -z "$CLI_TICKET" ]; then
+    echo "trampollm: --comment-bounces requires --ticket" >&2
+    usage >&2
+    exit 1
+  fi
 
-  local prompt
-  prompt="$(build_prompt "$PROMPT")"
+  local run_dir="memory/trampoline/${RUN_ID}"
+  # An unchecked mkdir is a 3am failure mode: on a read-only mount or a full
+  # disk every subsequent `>"$out_json"` redirect fails BEFORE claude is
+  # execed, the loop reads that as an API error, burns RETRIES+1 attempts,
+  # and then cannot write TRIPPED.md either -- so the run dies with a wall of
+  # "No such file or directory" and no artifact at all. Fail here instead.
+  if ! mkdir -p "$run_dir" 2>/dev/null; then
+    echo "trampollm: cannot create run directory '$run_dir' (read-only, full, or bad --run-id?)" >&2
+    exit 1
+  fi
+  if [ ! -w "$run_dir" ]; then
+    echo "trampollm: run directory '$run_dir' is not writable" >&2
+    exit 1
+  fi
+  # A stale TRIPPED.md from an earlier run reusing this --run-id would
+  # outlive a subsequent clean run and make it look like it tripped.
+  if [ -f "$run_dir/TRIPPED.md" ]; then
+    log "run dir $run_dir already holds a TRIPPED.md from an earlier run with this --run-id; removing it"
+    rm -f "$run_dir/TRIPPED.md"
+  fi
+
+  local prompt seed
+  seed="$PROMPT"
+  prompt="$(build_prompt "$seed")"
 
   local bounce=0
   local cum_cost="0"
@@ -341,32 +464,47 @@ main() {
   local corrected_malformed=false
   local last_good_block=""
 
+  # Installed only here (not at source time, so the test harness can source
+  # this file for its pure helpers without inheriting a trap). Every local it
+  # reads is already assigned above; the :- guards are belt-and-braces
+  # against `set -u` should that ever stop being true.
+  trap 'log "exit $? after ${bounce:-0} bounce(s), cumulative cost \$${cum_cost:-0} -- artifacts in ${run_dir:-?}"' EXIT
+
+  log "run ${RUN_ID}: starting, agent=$AGENT, max-bounces=$MAX_BOUNCES, max-cost-usd=$MAX_COST_USD, artifacts in $run_dir"
+
   while :; do
     if [ "$bounce" -ge "$MAX_BOUNCES" ]; then
+      log "TRIP: --max-bounces $MAX_BOUNCES reached"
       write_tripped "$run_dir" "max-bounces" "$bounce" "$cum_cost" "$last_good_block"
       escalate_ticket "$TICKET" "$run_dir/TRIPPED.md"
       exit 3
     fi
 
     if awk -v c="$cum_cost" -v m="$MAX_COST_USD" 'BEGIN { exit !(c >= m) }'; then
+      log "TRIP: cumulative cost \$$cum_cost reached --max-cost-usd $MAX_COST_USD"
       write_tripped "$run_dir" "max-cost-usd" "$bounce" "$cum_cost" "$last_good_block"
       escalate_ticket "$TICKET" "$run_dir/TRIPPED.md"
       exit 5
     fi
 
     bounce=$((bounce + 1))
-    local out_json="$run_dir/$(printf '%03d' "$bounce")-response.json"
-    local err_log="$run_dir/$(printf '%03d' "$bounce")-stderr.log"
+    local out_json err_log padded
+    padded="$(printf '%03d' "$bounce")"
+    out_json="$run_dir/${padded}-response.json"
+    err_log="$run_dir/${padded}-stderr.log"
 
     local attempt=0
     local rc
     while :; do
       run_claude "$prompt" "$AGENT" "$out_json" "$err_log"
       rc=$?
+      # Bill first, judge second: a dispatch that failed still cost money.
+      accumulate_cost "$out_json"
       if ! is_bad_response "$rc" "$out_json"; then
         break
       fi
       attempt=$((attempt + 1))
+      log "bounce $bounce: dispatch failed (rc=$rc), attempt $attempt of $((RETRIES + 1)); see $err_log"
       # --retries N means N retries AFTER the initial attempt, i.e. N+1
       # total dispatches per bounce on continuous failure: attempt only
       # trips once it exceeds RETRIES (strictly greater than), not on
@@ -376,12 +514,24 @@ main() {
         escalate_ticket "$TICKET" "$run_dir/TRIPPED.md"
         exit 1
       fi
+      # The cost rail is checked at the top of every bounce, but retries are
+      # dispatches too: without this, a bounce whose attempts each bill
+      # heavily could blow clean through the cumulative cap before the loop
+      # ever gets back to the top. Only reached on the retry path, so a
+      # successful bounce that lands exactly on the cap still completes.
+      if awk -v c="$cum_cost" -v m="$MAX_COST_USD" 'BEGIN { exit !(c >= m) }'; then
+        log "cumulative cost $cum_cost reached --max-cost-usd $MAX_COST_USD mid-bounce; stopping retries"
+        write_tripped "$run_dir" "max-cost-usd" "$bounce" "$cum_cost" "$last_good_block"
+        escalate_ticket "$TICKET" "$run_dir/TRIPPED.md"
+        exit 5
+      fi
+      # Keep the failed attempt's artifacts; the retry is about to clobber
+      # the canonical NNN- paths. The LAST (fatal) attempt deliberately keeps
+      # the canonical name, since that is the one an operator opens first.
+      mv -f "$out_json" "$run_dir/${padded}-attempt${attempt}-response.json" 2>/dev/null
+      mv -f "$err_log" "$run_dir/${padded}-attempt${attempt}-stderr.log" 2>/dev/null
       backoff_sleep "$attempt"
     done
-
-    local bounce_cost
-    bounce_cost="$(jq -r '.total_cost_usd // 0' "$out_json")"
-    cum_cost="$(awk -v a="$cum_cost" -v b="$bounce_cost" 'BEGIN { printf "%s", a + b }')"
 
     local result
     result="$(jq -r '.result // empty' "$out_json")"
@@ -398,7 +548,16 @@ main() {
       *)
         if [ "$corrected_malformed" = false ]; then
           corrected_malformed=true
-          prompt="$(build_prompt "$MALFORMED_CORRECTION")"
+          log "bounce $bounce: no valid baton; re-prompting once with the correction"
+          # Re-send the SEED alongside the correction. Every bounce is a fresh
+          # context window -- the preamble says so explicitly -- so a bare
+          # correction asks a model that has never seen the task to "re-emit"
+          # something it has no knowledge of. That paid bounce could only ever
+          # produce another malformed baton, turning a recoverable hiccup into
+          # a guaranteed exit-1 trip.
+          prompt="$(build_prompt "$seed
+
+$MALFORMED_CORRECTION")"
           continue
         else
           write_tripped "$run_dir" "malformed-baton" "$bounce" "$cum_cost" "$last_good_block"
@@ -411,6 +570,11 @@ main() {
 
     write_baton_file "$run_dir" "$bounce" "$block"
     last_good_block="$block"
+    log "bounce $bounce: status=$status agent=$AGENT cumulative cost \$$cum_cost"
+
+    if [ "$COMMENT_BOUNCES" = true ]; then
+      comment_bounce "$CLI_TICKET" "$run_dir/${padded}-baton.md" "$bounce"
+    fi
 
     if [ -z "$TICKET" ]; then
       local baton_ticket
@@ -430,10 +594,17 @@ main() {
     fi
 
     if [ "$identical_count" -eq 2 ]; then
-      prompt="$(build_prompt "$IDENTICAL_CORRECTION")"
+      log "bounce $bounce: identical baton; re-prompting once with the correction"
+      # Same fresh-context reasoning as the malformed path: the repeated
+      # baton has to travel WITH the scolding, or the corrective bounce is
+      # told to "change your approach" with no idea what the approach was.
+      prompt="$(build_prompt "$block
+
+$IDENTICAL_CORRECTION")"
       continue
     fi
     if [ "$identical_count" -ge 3 ]; then
+      log "TRIP: identical baton $identical_count times running (insanity loop)"
       write_tripped "$run_dir" "loop-detected" "$bounce" "$cum_cost" "$last_good_block"
       escalate_ticket "$TICKET" "$run_dir/TRIPPED.md"
       exit 4
@@ -441,11 +612,13 @@ main() {
 
     case "$status" in
       DONE)
+        log "DONE: relay terminated cleanly at bounce $bounce"
         exit 0
         ;;
       PARK|ESCALATE)
         local rail
         rail="$(printf '%s' "$status" | tr '[:upper:]' '[:lower:]')"
+        log "TRIP: relay stopped by status: $status"
         write_tripped "$run_dir" "$rail" "$bounce" "$cum_cost" "$last_good_block"
         escalate_ticket "$TICKET" "$run_dir/TRIPPED.md"
         exit 2
@@ -456,7 +629,8 @@ main() {
         if [ -n "$next_agent" ] && [ "$next_agent" != "<same>" ]; then
           AGENT="$next_agent"
         fi
-        prompt="$(build_prompt "$block")"
+        seed="$block"
+        prompt="$(build_prompt "$seed")"
         ;;
     esac
   done

--- a/scripts/trampollm.sh
+++ b/scripts/trampollm.sh
@@ -132,7 +132,7 @@ build_prompt() {
 # Reads MAX_TURNS / MAX_BUDGET_USD / MODEL from the enclosing script's
 # (non-local) variables set by main()'s argument parsing.
 run_claude() {
-  local prompt="$1" agent="$2" out_json="$3"
+  local prompt="$1" agent="$2" out_json="$3" err_log="$4"
   local args=(-p "$prompt" --output-format json --agent "$agent" --max-turns "${MAX_TURNS:-$DEFAULT_MAX_TURNS}")
   if [ -n "${MAX_BUDGET_USD:-}" ]; then
     args+=(--max-budget-usd "$MAX_BUDGET_USD")
@@ -140,7 +140,7 @@ run_claude() {
   if [ -n "${MODEL:-}" ]; then
     args+=(--model "$MODEL")
   fi
-  claude "${args[@]}" >"$out_json" 2>/dev/null
+  claude "${args[@]}" >"$out_json" 2>"$err_log"
   return $?
 }
 
@@ -198,6 +198,10 @@ escalate_ticket() {
   if [ -z "$ticket" ]; then
     return 0
   fi
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "trampollm: gh not found; skipping escalation (TRIPPED.md was still written)" >&2
+    return 0
+  fi
   local num="${ticket#\#}"
   gh issue comment "$num" --body-file "$tripped_path" >/dev/null
   gh issue edit "$num" --add-label needs-human >/dev/null
@@ -226,11 +230,29 @@ Options:
   --max-turns <N>           Native pass-through per call (default: 50)
   --max-budget-usd <X>      Native pass-through per call (unset by default)
   --max-cost-usd <X>        Cumulative cap across bounces (default: 10.00) -> exit 5
-  --retries <N>             Error retries per bounce (default: 3)
+  --retries <N>             Retries after the initial attempt (default: 3)
+                            -- N+1 total dispatches per bounce on failure
   --ticket <#NNN>           Seeds ticket; trips post a comment + needs-human label
   --run-id <id>             Overridable run id (default: timestamp-pid)
   --model <model>           Native pass-through when set
+
+Every option above requires a value; a trailing flag with no value
+(e.g. "trampollm.sh --prompt") is a usage error -> exit 1.
 EOF
+}
+
+# require_flag_value <flag> <remaining_arg_count> — exits 1 with a usage
+# error if <remaining_arg_count> is less than 2, i.e. <flag> is the last
+# positional and has no following value. Without this guard, "${2:-}" masks
+# the missing value under `set -u` and a lone trailing flag spins the
+# option-parsing loop forever ($# never decrements).
+require_flag_value() {
+  local flag="$1" remaining="$2"
+  if [ "$remaining" -lt 2 ]; then
+    echo "trampollm: missing value for $flag" >&2
+    usage >&2
+    exit 1
+  fi
 }
 
 main() {
@@ -250,16 +272,16 @@ main() {
 
   while [ $# -gt 0 ]; do
     case "$1" in
-      --prompt) PROMPT="${2:-}"; shift 2 ;;
-      --agent) AGENT="${2:-}"; shift 2 ;;
-      --max-bounces) MAX_BOUNCES="${2:-}"; shift 2 ;;
-      --max-turns) MAX_TURNS="${2:-}"; shift 2 ;;
-      --max-budget-usd) MAX_BUDGET_USD="${2:-}"; shift 2 ;;
-      --max-cost-usd) MAX_COST_USD="${2:-}"; shift 2 ;;
-      --retries) RETRIES="${2:-}"; shift 2 ;;
-      --ticket) TICKET="${2:-}"; shift 2 ;;
-      --run-id) RUN_ID="${2:-}"; shift 2 ;;
-      --model) MODEL="${2:-}"; shift 2 ;;
+      --prompt) require_flag_value "$1" "$#"; PROMPT="$2"; shift 2 ;;
+      --agent) require_flag_value "$1" "$#"; AGENT="$2"; shift 2 ;;
+      --max-bounces) require_flag_value "$1" "$#"; MAX_BOUNCES="$2"; shift 2 ;;
+      --max-turns) require_flag_value "$1" "$#"; MAX_TURNS="$2"; shift 2 ;;
+      --max-budget-usd) require_flag_value "$1" "$#"; MAX_BUDGET_USD="$2"; shift 2 ;;
+      --max-cost-usd) require_flag_value "$1" "$#"; MAX_COST_USD="$2"; shift 2 ;;
+      --retries) require_flag_value "$1" "$#"; RETRIES="$2"; shift 2 ;;
+      --ticket) require_flag_value "$1" "$#"; TICKET="$2"; shift 2 ;;
+      --run-id) require_flag_value "$1" "$#"; RUN_ID="$2"; shift 2 ;;
+      --model) require_flag_value "$1" "$#"; MODEL="$2"; shift 2 ;;
       -h|--help) usage; exit 0 ;;
       *) echo "trampollm: unknown argument: $1" >&2; usage >&2; exit 1 ;;
     esac
@@ -299,17 +321,22 @@ main() {
 
     bounce=$((bounce + 1))
     local out_json="$run_dir/$(printf '%03d' "$bounce")-response.json"
+    local err_log="$run_dir/$(printf '%03d' "$bounce")-stderr.log"
 
     local attempt=0
     local rc
     while :; do
-      run_claude "$prompt" "$AGENT" "$out_json"
+      run_claude "$prompt" "$AGENT" "$out_json" "$err_log"
       rc=$?
       if ! is_bad_response "$rc" "$out_json"; then
         break
       fi
       attempt=$((attempt + 1))
-      if [ "$attempt" -ge "$RETRIES" ]; then
+      # --retries N means N retries AFTER the initial attempt, i.e. N+1
+      # total dispatches per bounce on continuous failure: attempt only
+      # trips once it exceeds RETRIES (strictly greater than), not on
+      # reaching it.
+      if [ "$attempt" -gt "$RETRIES" ]; then
         write_tripped "$run_dir" "error" "$bounce" "$cum_cost" "$last_good_block"
         escalate_ticket "$TICKET" "$run_dir/TRIPPED.md"
         exit 1

--- a/scripts/trampollm.sh
+++ b/scripts/trampollm.sh
@@ -255,6 +255,41 @@ require_flag_value() {
   fi
 }
 
+# validate_nonneg_int <flag> <value> — exits 1 with a usage error unless
+# <value> is a bare non-negative integer. Without this guard, a non-numeric
+# --max-bounces/--retries silently disables that rail: `[ "$x" -ge "$y" ]`
+# fails with "integer expression expected", the surrounding `if` treats the
+# shell error as false (not a trip), and under `set -uo pipefail` (no -e)
+# the script sails on with the cap permanently inert -- observed to spin
+# forever against a stub that always errors, once --retries is non-numeric.
+validate_nonneg_int() {
+  local flag="$1" value="$2"
+  case "$value" in
+    ''|*[!0-9]*)
+      echo "trampollm: $flag requires a non-negative integer, got: $value" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+}
+
+# validate_nonneg_number <flag> <value> — exits 1 with a usage error unless
+# <value> is a non-negative integer or decimal. Guards --max-cost-usd /
+# --max-budget-usd, whose comparisons go through awk: a non-numeric value
+# there doesn't error loudly, it silently makes the cost rail inert (awk
+# falls back to string comparison, and a numeric-looking cumulative cost
+# string always sorts below a letter-leading string).
+validate_nonneg_number() {
+  local flag="$1" value="$2"
+  case "$value" in
+    ''|*[!0-9.]*|*.*.*|.|*.)
+      echo "trampollm: $flag requires a non-negative number, got: $value" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+}
+
 main() {
   require_jq || exit 1
 
@@ -274,11 +309,11 @@ main() {
     case "$1" in
       --prompt) require_flag_value "$1" "$#"; PROMPT="$2"; shift 2 ;;
       --agent) require_flag_value "$1" "$#"; AGENT="$2"; shift 2 ;;
-      --max-bounces) require_flag_value "$1" "$#"; MAX_BOUNCES="$2"; shift 2 ;;
-      --max-turns) require_flag_value "$1" "$#"; MAX_TURNS="$2"; shift 2 ;;
-      --max-budget-usd) require_flag_value "$1" "$#"; MAX_BUDGET_USD="$2"; shift 2 ;;
-      --max-cost-usd) require_flag_value "$1" "$#"; MAX_COST_USD="$2"; shift 2 ;;
-      --retries) require_flag_value "$1" "$#"; RETRIES="$2"; shift 2 ;;
+      --max-bounces) require_flag_value "$1" "$#"; validate_nonneg_int "$1" "$2"; MAX_BOUNCES="$2"; shift 2 ;;
+      --max-turns) require_flag_value "$1" "$#"; validate_nonneg_int "$1" "$2"; MAX_TURNS="$2"; shift 2 ;;
+      --max-budget-usd) require_flag_value "$1" "$#"; validate_nonneg_number "$1" "$2"; MAX_BUDGET_USD="$2"; shift 2 ;;
+      --max-cost-usd) require_flag_value "$1" "$#"; validate_nonneg_number "$1" "$2"; MAX_COST_USD="$2"; shift 2 ;;
+      --retries) require_flag_value "$1" "$#"; validate_nonneg_int "$1" "$2"; RETRIES="$2"; shift 2 ;;
       --ticket) require_flag_value "$1" "$#"; TICKET="$2"; shift 2 ;;
       --run-id) require_flag_value "$1" "$#"; RUN_ID="$2"; shift 2 ;;
       --model) require_flag_value "$1" "$#"; MODEL="$2"; shift 2 ;;

--- a/scripts/trampollm.sh
+++ b/scripts/trampollm.sh
@@ -1,0 +1,405 @@
+#!/usr/bin/env bash
+# FEAT-018: trampollm — continuation trampoline for `claude -p` bounces,
+# chained via the BATON v1 contract. See docs/baton.md for the schema.
+#
+# Dependencies: bash + jq + claude only.
+#
+# Usage:
+#   trampollm.sh --prompt "<initial task prompt>" [OPTIONS]
+#
+# Exit codes:
+#   0  status: DONE reached (clean sentinel termination)
+#   1  usage/error trip: retries exhausted, unrecoverable is_error, or
+#      malformed baton after one correction
+#   2  status: PARK or ESCALATE
+#   3  --max-bounces exceeded
+#   4  loop detected (identical baton)
+#   5  cumulative --max-cost-usd exceeded
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+DEFAULT_AGENT="dev"
+DEFAULT_MAX_BOUNCES=10
+DEFAULT_MAX_TURNS=50
+DEFAULT_MAX_COST_USD="10.00"
+DEFAULT_RETRIES=3
+
+RELAY_PREAMBLE='You are participating in an automated multi-bounce relay chain (trampollm). Read the context below, do the necessary work, then hand off to your successor.
+
+Relay rules:
+- Each bounce is a fresh context window; you cannot see any prior conversation except what is provided below.
+- You MUST end your final message with a complete "--- BATON v1 ---" ... "--- END BATON ---" block.
+- Set status: to exactly one of CONTINUE | DONE | PARK | ESCALATE.
+- status: CONTINUE means another bounce will pick up your baton verbatim as its seed context.
+- status: DONE means the relay terminates successfully.
+- status: PARK or ESCALATE means the relay stops here and a human is notified.
+- Emit exactly ONE baton block. If more than one appears, the LAST one is used.
+
+--- CONTEXT ---
+'
+
+MALFORMED_CORRECTION='Your previous reply had no valid BATON v1 block (or an invalid status). Re-emit ending with a complete "--- BATON v1 ---" ... "--- END BATON ---" block, with status: set to one of CONTINUE|DONE|PARK|ESCALATE.'
+
+IDENTICAL_CORRECTION='Identical baton detected across bounces (no forward progress). Change your approach and make concrete progress, or set status: PARK if you cannot proceed.'
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-testable by sourcing this file)
+# ---------------------------------------------------------------------------
+
+require_jq() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "trampollm: jq is required (install: 'apt-get install jq' / 'brew install jq')" >&2
+    return 1
+  fi
+  return 0
+}
+
+# parse_baton <text> — prints the block between "--- BATON v1 ---" and
+# "--- END BATON ---" (inclusive). Prints empty string if absent. If the
+# text contains multiple blocks, the LAST one wins.
+parse_baton() {
+  local text="$1"
+  printf '%s\n' "$text" | awk '
+    /--- BATON v1 ---/ { inblock=1; buf="" }
+    inblock            { buf = buf $0 "\n" }
+    /--- END BATON ---/ { if (inblock) { block = buf; inblock = 0 } }
+    END { printf "%s", block }
+  '
+}
+
+# baton_field <block> <key> — prints the value after "<key>:", whitespace-trimmed.
+baton_field() {
+  local block="$1" key="$2"
+  printf '%s\n' "$block" | awk -v k="$key" '
+    {
+      line = $0
+      sub(/^[ \t]+/, "", line)
+      prefix = k ":"
+      if (substr(line, 1, length(prefix)) == prefix) {
+        val = substr(line, length(prefix) + 1)
+        sub(/^[ \t]+/, "", val)
+        sub(/[ \t]+$/, "", val)
+        print val
+        exit
+      }
+    }
+  '
+}
+
+# baton_status <block> — baton_field block status, uppercased.
+baton_status() {
+  local block="$1"
+  baton_field "$block" "status" | tr '[:lower:]' '[:upper:]'
+}
+
+# normalize_baton <block> — strip per-line whitespace, drop the breadcrumbs:
+# line entirely, collapse (drop) blank lines. Output feeds hash_baton.
+normalize_baton() {
+  local block="$1"
+  printf '%s\n' "$block" | awk '
+    {
+      line = $0
+      sub(/^[ \t]+/, "", line)
+      sub(/[ \t]+$/, "", line)
+      if (line ~ /^breadcrumbs:/) next
+      if (line == "") next
+      print line
+    }
+  '
+}
+
+# hash_baton <block> — stable hash of the normalized block.
+hash_baton() {
+  local block="$1"
+  normalize_baton "$block" | cksum | awk '{print $1}'
+}
+
+# build_prompt <seed> — prepend the fixed relay preamble to <seed>.
+build_prompt() {
+  local seed="$1"
+  printf '%s\n%s' "$RELAY_PREAMBLE" "$seed"
+}
+
+# ---------------------------------------------------------------------------
+# Effectful helpers
+# ---------------------------------------------------------------------------
+
+# run_claude <prompt> <agent> <out_json> — invokes claude, writes stdout JSON
+# to <out_json>, returns claude's exit code. Never parses .result itself.
+# Reads MAX_TURNS / MAX_BUDGET_USD / MODEL from the enclosing script's
+# (non-local) variables set by main()'s argument parsing.
+run_claude() {
+  local prompt="$1" agent="$2" out_json="$3"
+  local args=(-p "$prompt" --output-format json --agent "$agent" --max-turns "${MAX_TURNS:-$DEFAULT_MAX_TURNS}")
+  if [ -n "${MAX_BUDGET_USD:-}" ]; then
+    args+=(--max-budget-usd "$MAX_BUDGET_USD")
+  fi
+  if [ -n "${MODEL:-}" ]; then
+    args+=(--model "$MODEL")
+  fi
+  claude "${args[@]}" >"$out_json" 2>/dev/null
+  return $?
+}
+
+# is_bad_response <rc> <out_json> — true (0) when the bounce must be treated
+# as an error: non-zero exit, invalid JSON, is_error:true, or empty .result.
+# Gate on exit code AND .is_error — never on .subtype (stays "success" on
+# API errors; the FEAT-017 spike's gotcha).
+is_bad_response() {
+  local rc="$1" out_json="$2"
+  if [ "$rc" -ne 0 ]; then
+    return 0
+  fi
+  if [ ! -s "$out_json" ]; then
+    return 0
+  fi
+  if ! jq -e . "$out_json" >/dev/null 2>&1; then
+    return 0
+  fi
+  if [ "$(jq -r '.is_error // false' "$out_json")" = "true" ]; then
+    return 0
+  fi
+  local result
+  result="$(jq -r '.result // empty' "$out_json")"
+  if [ -z "$result" ]; then
+    return 0
+  fi
+  return 1
+}
+
+# write_baton_file <run_dir> <n> <block> — writes <run_dir>/NNN-baton.md verbatim.
+write_baton_file() {
+  local run_dir="$1" n="$2" block="$3"
+  printf '%s\n' "$block" >"$run_dir/$(printf '%03d' "$n")-baton.md"
+}
+
+# write_tripped <run_dir> <rail> <bounce> <cum_cost> <last_baton>
+write_tripped() {
+  local run_dir="$1" rail="$2" bounce="$3" cum_cost="$4" last_baton="$5"
+  {
+    echo "trampollm: TRIPPED"
+    echo ""
+    echo "rail: $rail"
+    echo "bounce: $bounce"
+    echo "cumulative_cost_usd: $cum_cost"
+    echo ""
+    echo "--- last good baton (resume by feeding this back in) ---"
+    printf '%s\n' "$last_baton"
+  } >"$run_dir/TRIPPED.md"
+}
+
+# escalate_ticket <ticket> <tripped_path> — when <ticket> is non-empty, posts
+# a machine comment (batons are unsigned by design) and adds needs-human.
+escalate_ticket() {
+  local ticket="$1" tripped_path="$2"
+  if [ -z "$ticket" ]; then
+    return 0
+  fi
+  local num="${ticket#\#}"
+  gh issue comment "$num" --body-file "$tripped_path" >/dev/null
+  gh issue edit "$num" --add-label needs-human >/dev/null
+}
+
+# backoff_sleep <attempt> — sleep(TRAMPOLLM_BACKOFF_BASE * attempt).
+# Testability hook: TRAMPOLLM_BACKOFF_BASE=0 in tests so no real waiting.
+backoff_sleep() {
+  local attempt="$1"
+  local base="${TRAMPOLLM_BACKOFF_BASE:-2}"
+  sleep "$((base * attempt))"
+}
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+usage() {
+  cat <<'EOF'
+Usage: trampollm.sh --prompt "<initial task prompt>" [OPTIONS]
+
+Options:
+  --prompt <text>          Seed prompt for bounce 1 (required)
+  --agent <role>            Persona for bounce 1 (default: dev)
+  --max-bounces <N>         Cross-bounce ceiling (default: 10) -> exit 3
+  --max-turns <N>           Native pass-through per call (default: 50)
+  --max-budget-usd <X>      Native pass-through per call (unset by default)
+  --max-cost-usd <X>        Cumulative cap across bounces (default: 10.00) -> exit 5
+  --retries <N>             Error retries per bounce (default: 3)
+  --ticket <#NNN>           Seeds ticket; trips post a comment + needs-human label
+  --run-id <id>             Overridable run id (default: timestamp-pid)
+  --model <model>           Native pass-through when set
+EOF
+}
+
+main() {
+  require_jq || exit 1
+
+  local PROMPT=""
+  AGENT="$DEFAULT_AGENT"
+  local MAX_BOUNCES="$DEFAULT_MAX_BOUNCES"
+  MAX_TURNS="$DEFAULT_MAX_TURNS"
+  MAX_BUDGET_USD=""
+  local MAX_COST_USD="$DEFAULT_MAX_COST_USD"
+  local RETRIES="$DEFAULT_RETRIES"
+  local TICKET=""
+  local RUN_ID
+  RUN_ID="$(date +%Y%m%dT%H%M%S)-$$"
+  MODEL=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --prompt) PROMPT="${2:-}"; shift 2 ;;
+      --agent) AGENT="${2:-}"; shift 2 ;;
+      --max-bounces) MAX_BOUNCES="${2:-}"; shift 2 ;;
+      --max-turns) MAX_TURNS="${2:-}"; shift 2 ;;
+      --max-budget-usd) MAX_BUDGET_USD="${2:-}"; shift 2 ;;
+      --max-cost-usd) MAX_COST_USD="${2:-}"; shift 2 ;;
+      --retries) RETRIES="${2:-}"; shift 2 ;;
+      --ticket) TICKET="${2:-}"; shift 2 ;;
+      --run-id) RUN_ID="${2:-}"; shift 2 ;;
+      --model) MODEL="${2:-}"; shift 2 ;;
+      -h|--help) usage; exit 0 ;;
+      *) echo "trampollm: unknown argument: $1" >&2; usage >&2; exit 1 ;;
+    esac
+  done
+
+  if [ -z "$PROMPT" ]; then
+    echo "trampollm: --prompt is required" >&2
+    usage >&2
+    exit 1
+  fi
+
+  local run_dir="memory/trampoline/${RUN_ID}"
+  mkdir -p "$run_dir"
+
+  local prompt
+  prompt="$(build_prompt "$PROMPT")"
+
+  local bounce=0
+  local cum_cost="0"
+  local last_hash=""
+  local identical_count=0
+  local corrected_malformed=false
+  local last_good_block=""
+
+  while :; do
+    if [ "$bounce" -ge "$MAX_BOUNCES" ]; then
+      write_tripped "$run_dir" "max-bounces" "$bounce" "$cum_cost" "$last_good_block"
+      escalate_ticket "$TICKET" "$run_dir/TRIPPED.md"
+      exit 3
+    fi
+
+    if awk -v c="$cum_cost" -v m="$MAX_COST_USD" 'BEGIN { exit !(c >= m) }'; then
+      write_tripped "$run_dir" "max-cost-usd" "$bounce" "$cum_cost" "$last_good_block"
+      escalate_ticket "$TICKET" "$run_dir/TRIPPED.md"
+      exit 5
+    fi
+
+    bounce=$((bounce + 1))
+    local out_json="$run_dir/$(printf '%03d' "$bounce")-response.json"
+
+    local attempt=0
+    local rc
+    while :; do
+      run_claude "$prompt" "$AGENT" "$out_json"
+      rc=$?
+      if ! is_bad_response "$rc" "$out_json"; then
+        break
+      fi
+      attempt=$((attempt + 1))
+      if [ "$attempt" -ge "$RETRIES" ]; then
+        write_tripped "$run_dir" "error" "$bounce" "$cum_cost" "$last_good_block"
+        escalate_ticket "$TICKET" "$run_dir/TRIPPED.md"
+        exit 1
+      fi
+      backoff_sleep "$attempt"
+    done
+
+    local bounce_cost
+    bounce_cost="$(jq -r '.total_cost_usd // 0' "$out_json")"
+    cum_cost="$(awk -v a="$cum_cost" -v b="$bounce_cost" 'BEGIN { printf "%s", a + b }')"
+
+    local result
+    result="$(jq -r '.result // empty' "$out_json")"
+    local block
+    block="$(parse_baton "$result")"
+
+    local status=""
+    if [ -n "$block" ]; then
+      status="$(baton_status "$block")"
+    fi
+
+    case "$status" in
+      CONTINUE|DONE|PARK|ESCALATE) ;;
+      *)
+        if [ "$corrected_malformed" = false ]; then
+          corrected_malformed=true
+          prompt="$(build_prompt "$MALFORMED_CORRECTION")"
+          continue
+        else
+          write_tripped "$run_dir" "malformed-baton" "$bounce" "$cum_cost" "$last_good_block"
+          escalate_ticket "$TICKET" "$run_dir/TRIPPED.md"
+          exit 1
+        fi
+        ;;
+    esac
+    corrected_malformed=false
+
+    write_baton_file "$run_dir" "$bounce" "$block"
+    last_good_block="$block"
+
+    if [ -z "$TICKET" ]; then
+      local baton_ticket
+      baton_ticket="$(baton_field "$block" "ticket")"
+      if [ -n "$baton_ticket" ]; then
+        TICKET="$baton_ticket"
+      fi
+    fi
+
+    local h
+    h="$(hash_baton "$block")"
+    if [ "$h" = "$last_hash" ]; then
+      identical_count=$((identical_count + 1))
+    else
+      identical_count=1
+      last_hash="$h"
+    fi
+
+    if [ "$identical_count" -eq 2 ]; then
+      prompt="$(build_prompt "$IDENTICAL_CORRECTION")"
+      continue
+    fi
+    if [ "$identical_count" -ge 3 ]; then
+      write_tripped "$run_dir" "loop-detected" "$bounce" "$cum_cost" "$last_good_block"
+      escalate_ticket "$TICKET" "$run_dir/TRIPPED.md"
+      exit 4
+    fi
+
+    case "$status" in
+      DONE)
+        exit 0
+        ;;
+      PARK|ESCALATE)
+        local rail
+        rail="$(printf '%s' "$status" | tr '[:upper:]' '[:lower:]')"
+        write_tripped "$run_dir" "$rail" "$bounce" "$cum_cost" "$last_good_block"
+        escalate_ticket "$TICKET" "$run_dir/TRIPPED.md"
+        exit 2
+        ;;
+      CONTINUE)
+        local next_agent
+        next_agent="$(baton_field "$block" "next-agent")"
+        if [ -n "$next_agent" ] && [ "$next_agent" != "<same>" ]; then
+          AGENT="$next_agent"
+        fi
+        prompt="$(build_prompt "$block")"
+        ;;
+    esac
+  done
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  main "$@"
+fi


### PR DESCRIPTION
## Summary

Implements FEAT-018 v1 per the architect's TDD plan (issue #108), following the
FEAT-017 spike findings (#107) exactly:

- **`scripts/trampollm.sh`** — the continuation trampoline. Chains fresh
  `claude -p ... --output-format json` bounces via the BATON v1 sentinel
  contract. Supports next-agent routing, per-bounce native pass-through
  flags (`--max-turns`, `--max-budget-usd`, `--model`), and five independent
  rails, each with a distinct exit code: `--max-bounces` (3), cumulative
  `--max-cost-usd` checked *before* dispatch (5), identical-baton loop
  detection with exactly one corrective re-prompt (4), error-retry-with-backoff
  (1), and malformed-baton correction (1). `status: DONE` → 0, `PARK`/`ESCALATE`
  → 2. On any trip: writes `TRIPPED.md` (rail, bounce count, cumulative cost,
  last good baton verbatim) and — when a ticket is known — posts a `gh issue
  comment` and adds `needs-human`.
- Gates on exit code AND `.is_error` before trusting `.result`, never on
  `.subtype` — the FEAT-017 spike's gotcha: `subtype` stays `"success"` even
  on API errors.
- All float math uses `awk`, not `bc`, per the architect's explicit
  correction — keeps the dependency surface at bash + jq + claude only.
  `require_jq` fails fast with an install hint if `jq` is missing.
- Pure helpers (`parse_baton`, `baton_field`, `baton_status`, `normalize_baton`,
  `hash_baton`, `build_prompt`) are unit-testable by sourcing the script,
  guarded by `if [ "${BASH_SOURCE[0]}" = "$0" ]; then main "$@"; fi`.
- **`docs/baton.md`** — standalone BATON v1 schema doc: the fenced block, the
  field requirement table (fence + `status:` are hard; the rest is
  contract-by-convention), the status vocabulary, and the three neighbor
  relations from the spike (DX-038 tracker, FEAT-013 handoff, EPIC-005 k10s
  task ticket).
- No installer or slash-command changes (non-goals honored): downstream
  reaches the script through the submodule at `.ai-lindale/scripts/trampollm.sh`.

## Test plan

- [x] `bash scripts/tests/test-trampollm.sh` — **25/25 passing**, zero API
      spend. `claude` and `gh` are PATH shims (canned JSON fixtures / call
      loggers); the real CLIs are never invoked. Covers: pure-helper unit
      tests (Phase 1), the is_error-over-subtype gotcha (Phase 2),
      multi-bounce sentinel termination + next-agent routing + pass-through
      flags (Phase 3), all five rails including identical-baton loop
      detection and malformed-baton correction (Phase 4), and
      TRIPPED.md/gh-escalation observability (Phase 5).
- [x] `bash scripts/tests/test-adoption.sh` — **27/27 passing**, no
      regressions (trampollm ships via the submodule, not the installer).
- [x] `bash -n` syntax check on both new scripts.
- [x] TDD red/green: red commit (23/25 failing, script absent, confirmed
      before writing the implementation) landed locally first; green commit
      (implementation + fixes to two test-harness bugs found while turning
      red to green) pushed together with red.

Implements #108

-Claude Dev
