### PR TITLE
fix(ci): remove hook-enforcement test step orphaned by DX-035

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Hook enforcement tests
-        run: bash scripts/hooks/tests/test-hooks.sh
-
       - name: Install / adoption tests
         run: bash scripts/tests/test-adoption.sh


### PR DESCRIPTION
## Summary
CI has failed on every push/PR since the DX-035 merge (2026-07-06). Root cause: DX-035 (#86) deleted `scripts/hooks/` (vestigial enforcement scaffolding, per the EPIC-004 container-as-boundary pivot) but left the CI step that runs `scripts/hooks/tests/test-hooks.sh`, so every run dies with exit 127 in ~7s before any real tests execute.

## Change
- Remove the dead **Hook enforcement tests** step from `.github/workflows/ci.yml` (3 lines)
- The **Install / adoption tests** step (`scripts/tests/test-adoption.sh`) remains — verified locally: **27 passed, 0 failed**

## Verification
- `grep -rn test-hooks` — the only remaining reference was this workflow step
- This PR's own CI run is the end-to-end proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QS3a2cb3U7LUdxGxa4Zeub