### PR TITLE
fix(BUG-009): glob install.sh agent symlinks instead of hardcoding role list

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -124,13 +124,15 @@ mkdir -p .claude/agents .claude/commands
 
 # Symlink core agents and commands — skipped in self-host mode
 if [ "$SELF_HOST" = false ]; then
-  # Symlink core agents (only framework-managed roles)
-  for agent in architect tpm dev; do
-    src="../../${FRAMEWORK_DIR}/.claude/agents/${agent}.md"
-    dest=".claude/agents/${agent}.md"
-    if [ -f "$FRAMEWORK_DIR/.claude/agents/${agent}.md" ]; then
-      link_managed "$src" "$dest"
-    fi
+  # Symlink every framework agent (BUG-009: glob instead of a hardcoded
+  # role list, so new agents like researcher/audit-repo propagate downstream
+  # without another install.sh edit).
+  for agent_file in "$FRAMEWORK_DIR"/.claude/agents/*.md; do
+    [ -f "$agent_file" ] || continue
+    agent_basename=$(basename "$agent_file")
+    src="../../${FRAMEWORK_DIR}/.claude/agents/${agent_basename}"
+    dest=".claude/agents/${agent_basename}"
+    link_managed "$src" "$dest"
   done
 
   # Symlink core commands

--- a/scripts/tests/test-adoption.sh
+++ b/scripts/tests/test-adoption.sh
@@ -40,6 +40,13 @@ setup_project() {
   chmod +x "$FRAMEWORK/scripts/install.sh"
 }
 
+# Add non-core framework agent files (simulates researcher.md / audit-repo.md
+# landing upstream, per BUG-009) into the fake framework submodule.
+add_extra_agents() {
+  echo "# Researcher agent" > "$FRAMEWORK/.claude/agents/researcher.md"
+  echo "# Audit-repo agent" > "$FRAMEWORK/.claude/agents/audit-repo.md"
+}
+
 teardown() {
   if [ -n "$TMPDIR_BASE" ] && [ -d "$TMPDIR_BASE" ]; then
     rm -rf "$TMPDIR_BASE"
@@ -120,6 +127,29 @@ test_agent_symlinks() {
   for agent in architect tpm dev; do
     assert_symlink ".claude/agents/${agent}.md" "../../.ai-lindale/.claude/agents/${agent}.md"
   done
+}
+
+test_agent_symlinks_glob_includes_new_agents() {
+  # BUG-009: install.sh must not hardcode the agent list — any framework
+  # agent file (e.g. researcher.md, audit-repo.md) must symlink downstream.
+  setup_project
+  add_extra_agents
+  bash "$FRAMEWORK/scripts/install.sh"
+  assert_symlink ".claude/agents/researcher.md" "../../.ai-lindale/.claude/agents/researcher.md" &&
+  assert_symlink ".claude/agents/audit-repo.md" "../../.ai-lindale/.claude/agents/audit-repo.md"
+}
+
+test_agent_glob_preserves_project_owned_collision() {
+  # BUG-009 AC: a downstream project-owned agent at a colliding name must be
+  # skipped (not clobbered), even for names outside the old hardcoded set.
+  setup_project
+  add_extra_agents
+  setup_with_override ".claude/agents/researcher.md" "# project-owned researcher SME"
+  output=$(bash "$FRAMEWORK/scripts/install.sh" 2>&1)
+  assert_file_not_symlink ".claude/agents/researcher.md" &&
+  assert_file_contains ".claude/agents/researcher.md" "# project-owned researcher SME" &&
+  echo "$output" | grep -qi "skipped .claude/agents/researcher.md" &&
+  assert_symlink ".claude/agents/audit-repo.md" "../../.ai-lindale/.claude/agents/audit-repo.md"
 }
 
 test_command_symlinks() {
@@ -409,6 +439,8 @@ echo "=== DX-007 Adoption Tests ==="
 echo ""
 echo "--- install.sh tests ---"
 run_test "creates agent symlinks" test_agent_symlinks
+run_test "agent glob includes new (non-hardcoded) agents" test_agent_symlinks_glob_includes_new_agents
+run_test "agent glob preserves project-owned collision" test_agent_glob_preserves_project_owned_collision
 run_test "creates command symlinks" test_command_symlinks
 run_test "preserves project-owned files" test_preserves_project_files
 run_test "creates team-config.yml template" test_creates_team_config_template


### PR DESCRIPTION
Closes #102

`scripts/install.sh` symlinked agents via a hardcoded `for agent in architect tpm dev`, so any framework agent added after those three (e.g. researcher, audit-repo) never propagates downstream. This mirrors the same fix on the commands loop: glob `.claude/agents/*.md` through the existing `link_managed` helper instead of enumerating names.

BUG-007 local-override protection is unaffected — a project-owned file at a colliding agent name is still skipped, not clobbered.

Adds two tests to `scripts/tests/test-adoption.sh`: a synthetic non-hardcoded agent pair symlinks correctly (red before the fix, green after), and a project-owned override at a colliding non-core name is preserved.