### PR TITLE
fix(BUG-008): glob install.sh command symlinks instead of hardcoding list

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -135,13 +135,15 @@ if [ "$SELF_HOST" = false ]; then
     link_managed "$src" "$dest"
   done
 
-  # Symlink core commands
-  for cmd in architect tpm dev; do
-    src="../../${FRAMEWORK_DIR}/.claude/commands/${cmd}.md"
-    dest=".claude/commands/${cmd}.md"
-    if [ -f "$FRAMEWORK_DIR/.claude/commands/${cmd}.md" ]; then
-      link_managed "$src" "$dest"
-    fi
+  # Symlink every framework command (BUG-008: glob instead of a hardcoded
+  # command list, so commands like /autodev propagate downstream without
+  # another install.sh edit).
+  for cmd_file in "$FRAMEWORK_DIR"/.claude/commands/*.md; do
+    [ -f "$cmd_file" ] || continue
+    cmd_basename=$(basename "$cmd_file")
+    src="../../${FRAMEWORK_DIR}/.claude/commands/${cmd_basename}"
+    dest=".claude/commands/${cmd_basename}"
+    link_managed "$src" "$dest"
   done
 
   echo ""

--- a/scripts/tests/test-adoption.sh
+++ b/scripts/tests/test-adoption.sh
@@ -47,6 +47,13 @@ add_extra_agents() {
   echo "# Audit-repo agent" > "$FRAMEWORK/.claude/agents/audit-repo.md"
 }
 
+# Add the real autodev command (BUG-008) into the fake framework submodule —
+# it already exists upstream but setup_project's hardcoded architect/tpm/dev
+# copy loop above never picks it up.
+add_autodev_command() {
+  cp "$REPO_ROOT/.claude/commands/autodev.md" "$FRAMEWORK/.claude/commands/autodev.md"
+}
+
 teardown() {
   if [ -n "$TMPDIR_BASE" ] && [ -d "$TMPDIR_BASE" ]; then
     rm -rf "$TMPDIR_BASE"
@@ -158,6 +165,27 @@ test_command_symlinks() {
   for cmd in architect tpm dev; do
     assert_symlink ".claude/commands/${cmd}.md" "../../.ai-lindale/.claude/commands/${cmd}.md"
   done
+}
+
+test_command_glob_includes_autodev() {
+  # BUG-008: install.sh must not hardcode the command list — /autodev (and
+  # any future command) must symlink downstream.
+  setup_project
+  add_autodev_command
+  bash "$FRAMEWORK/scripts/install.sh"
+  assert_symlink ".claude/commands/autodev.md" "../../.ai-lindale/.claude/commands/autodev.md"
+}
+
+test_command_glob_preserves_project_owned_collision() {
+  # Mirrors BUG-009's override-safety AC for commands: a project-owned
+  # command at a colliding (non-core) name is skipped, not clobbered.
+  setup_project
+  add_autodev_command
+  setup_with_override ".claude/commands/autodev.md" "# project-owned autodev override"
+  output=$(bash "$FRAMEWORK/scripts/install.sh" 2>&1)
+  assert_file_not_symlink ".claude/commands/autodev.md" &&
+  assert_file_contains ".claude/commands/autodev.md" "# project-owned autodev override" &&
+  echo "$output" | grep -qi "skipped .claude/commands/autodev.md"
 }
 
 test_preserves_project_files() {
@@ -442,6 +470,8 @@ run_test "creates agent symlinks" test_agent_symlinks
 run_test "agent glob includes new (non-hardcoded) agents" test_agent_symlinks_glob_includes_new_agents
 run_test "agent glob preserves project-owned collision" test_agent_glob_preserves_project_owned_collision
 run_test "creates command symlinks" test_command_symlinks
+run_test "command glob includes /autodev (non-hardcoded)" test_command_glob_includes_autodev
+run_test "command glob preserves project-owned collision" test_command_glob_preserves_project_owned_collision
 run_test "preserves project-owned files" test_preserves_project_files
 run_test "creates team-config.yml template" test_creates_team_config_template
 run_test "does not overwrite existing config" test_does_not_overwrite_existing_config


### PR DESCRIPTION
Closes #84

Stacked on #111 (BUG-009) — base branch is `fix/BUG-009-install-agent-glob`, not `main`. GitHub will auto-retarget this PR to `main` once #111 merges.

Same bug class as BUG-009, one loop down: `scripts/install.sh` symlinked commands via a hardcoded `for cmd in architect tpm dev`, so `/autodev` (added in e1a9b69, DX-008) never reaches downstream installs. Glob `.claude/commands/*.md` through the existing `link_managed` helper instead of enumerating names, mirroring the agents-loop fix.

Adds two tests to `scripts/tests/test-adoption.sh`: `/autodev` symlinks correctly (red before the fix, green after), and a project-owned command override at a colliding name is still preserved.