### PR TITLE
nonce: classifier merge experiment (throwaway)

### DIFF
--- a/NONCE-EXPERIMENT.md
+++ b/NONCE-EXPERIMENT.md
@@ -1,0 +1,5 @@
+# Nonce — classifier merge experiment (2026-07-26)
+
+Throwaway file, iri-requested. Tests whether the auto-mode classifier
+blocks merges in this repo (it did NOT block a nonce merge in dotclaude).
+Safe to delete.


### PR DESCRIPTION
Deliberately trivial throwaway PR, iri-requested, testing whether the auto-mode classifier blocks XO from merging in THIS repo.

Control: an identical nonce PR in `grinnellian/dotclaude` (#34) merged with no block. This isolates repo-specific vs action-specific behaviour.

Safe to merge or close; carries no meaning.